### PR TITLE
fix: ensure embedding model loads from CDN

### DIFF
--- a/src/lib/services/embeddings.ts
+++ b/src/lib/services/embeddings.ts
@@ -57,7 +57,10 @@ export async function initEmbeddingModel(): Promise<boolean> {
 
 	try {
 		// Dynamic import to avoid SSR issues
-		const { pipeline: createPipeline } = await import('@xenova/transformers');
+		const { pipeline: createPipeline, env } = await import('@xenova/transformers');
+
+		// Ensure models load from Hugging Face CDN, not local path
+		env.allowLocalModels = false;
 
 		pipeline = await createPipeline('feature-extraction', MODEL_NAME, {
 			progress_callback: (progress: { status: string }) => {


### PR DESCRIPTION
## Problem

The Transformers.js embedding model was trying to load from a local `/models/` path instead of the Hugging Face CDN, causing 404 errors.

## Solution

Set `env.allowLocalModels = false` to ensure models always load from the CDN.