### PR TITLE
fix: move subdomain redirects to SvelteKit hooks

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,18 @@
+import { redirect, type Handle } from '@sveltejs/kit';
+
+export const handle: Handle = async ({ event, resolve }) => {
+	const host = event.request.headers.get('host') || '';
+
+	if (host.startsWith('app.')) {
+		const path = event.url.pathname === '/' ? '/app' : `/app${event.url.pathname}`;
+		redirect(301, `https://utsuwa.ai${path}`);
+	}
+
+	if (host.startsWith('docs.')) {
+		const path =
+			event.url.pathname === '/' ? '/docs/overview/introduction' : `/docs${event.url.pathname}`;
+		redirect(301, `https://utsuwa.ai${path}`);
+	}
+
+	return resolve(event);
+};

--- a/vercel.json
+++ b/vercel.json
@@ -1,16 +1,3 @@
 {
-	"redirects": [
-		{
-			"source": "/:path*",
-			"has": [{ "type": "host", "value": "app.utsuwa.ai" }],
-			"destination": "https://utsuwa.ai/app/:path*",
-			"permanent": true
-		},
-		{
-			"source": "/:path*",
-			"has": [{ "type": "host", "value": "docs.utsuwa.ai" }],
-			"destination": "https://utsuwa.ai/docs/:path*",
-			"permanent": true
-		}
-	]
+	"framework": "sveltekit"
 }


### PR DESCRIPTION
## Summary

- `vercel.json` redirects don't fire for prerendered static pages — Vercel serves the static HTML before evaluating redirect rules
- Moves subdomain redirect logic to `hooks.server.ts` which intercepts every request at the framework level
- `app.utsuwa.ai` → 301 → `utsuwa.ai/app`
- `docs.utsuwa.ai` → 301 → `utsuwa.ai/docs/overview/introduction`

## Test plan

- [x] Verify `app.utsuwa.ai` redirects to `utsuwa.ai/app`
- [x] Verify `docs.utsuwa.ai` redirects to `utsuwa.ai/docs/overview/introduction`
- [x] Verify `utsuwa.ai` landing page still works normally