### PR TITLE
Fix Ollama local model discovery and browser-origin setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"lint": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-		"test": "echo \"No tests configured\" && exit 0"
+		"test": "node --test --experimental-strip-types \"src/**/*.test.ts\""
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^7.0.0",

--- a/src/content/docs/guides/local-llm-setup.md
+++ b/src/content/docs/guides/local-llm-setup.md
@@ -191,6 +191,8 @@ If you're running Utsuwa in a browser and getting CORS errors with Ollama, set t
 OLLAMA_ORIGINS=https://www.utsuwa.ai,https://utsuwa.ai ollama serve
 ```
 
+Ollama documents this under [allowing additional web origins](https://docs.ollama.com/faq#how-can-i-allow-additional-web-origins-to-access-ollama).
+
 For Vercel previews, replace the value with the exact preview origin from the browser address bar:
 
 ```bash

--- a/src/content/docs/guides/local-llm-setup.md
+++ b/src/content/docs/guides/local-llm-setup.md
@@ -63,10 +63,16 @@ If the dropdown is empty, check your installed Ollama models with:
 ollama list
 ```
 
-If you are using the hosted website at `https://utsuwa.ai`, your browser connects directly to Ollama on your machine. Start Ollama with an allowed origin:
+If you are using the hosted website at `https://www.utsuwa.ai`, your browser connects directly to Ollama on your machine. Start Ollama with the Utsuwa origin allowed:
 
 ```bash
-OLLAMA_ORIGINS=https://utsuwa.ai ollama serve
+OLLAMA_ORIGINS=https://www.utsuwa.ai,https://utsuwa.ai ollama serve
+```
+
+If you are testing a Vercel preview, use the exact preview origin shown in the browser address bar, without the trailing slash:
+
+```bash
+OLLAMA_ORIGINS=https://your-preview.vercel.app ollama serve
 ```
 
 For local development, use:
@@ -136,7 +142,13 @@ The LLM server may not be running or your browser may not be allowed to access i
 If you are using the hosted website with Ollama, restart Ollama with:
 
 ```bash
-OLLAMA_ORIGINS=https://utsuwa.ai ollama serve
+OLLAMA_ORIGINS=https://www.utsuwa.ai,https://utsuwa.ai ollama serve
+```
+
+For a Vercel preview, use the exact preview origin:
+
+```bash
+OLLAMA_ORIGINS=https://your-preview.vercel.app ollama serve
 ```
 
 Then click the refresh icon in Utsuwa's model dropdown.
@@ -176,9 +188,15 @@ Make sure the URL in Utsuwa matches the port your server is using.
 If you're running Utsuwa in a browser and getting CORS errors with Ollama, set the origins environment variable before starting the server:
 
 ```bash
-OLLAMA_ORIGINS=https://utsuwa.ai ollama serve
+OLLAMA_ORIGINS=https://www.utsuwa.ai,https://utsuwa.ai ollama serve
 ```
 
-Use `OLLAMA_ORIGINS=http://localhost:5173` for local development, or `OLLAMA_ORIGINS=*` only if you intentionally want to allow any browser origin on your machine.
+For Vercel previews, replace the value with the exact preview origin from the browser address bar:
+
+```bash
+OLLAMA_ORIGINS=https://your-preview.vercel.app ollama serve
+```
+
+If you use multiple Utsuwa origins, comma-separate them. Use `OLLAMA_ORIGINS=http://localhost:5173` for local development, or `OLLAMA_ORIGINS=*` only if you intentionally want to allow any browser origin on your machine.
 
 This isn't needed when using the desktop app.

--- a/src/content/docs/guides/local-llm-setup.md
+++ b/src/content/docs/guides/local-llm-setup.md
@@ -52,8 +52,28 @@ This starts the Ollama API on `http://localhost:11434`.
 1. Open **Settings** (gear icon)
 2. Navigate to the **Character** tab
 3. Enable the LLM toggle, then select **Ollama** from the provider dropdown
-4. Select a model from the model dropdown (click the refresh icon to reload the list from your server)
-5. Start chatting
+4. Leave the base URL as `http://localhost:11434` unless you changed Ollama's port
+5. Utsuwa will fetch models installed on your machine. Click the refresh icon if you just pulled a new model.
+6. Select an installed model from the dropdown
+7. Start chatting
+
+If the dropdown is empty, check your installed Ollama models with:
+
+```bash
+ollama list
+```
+
+If you are using the hosted website at `https://utsuwa.ai`, your browser connects directly to Ollama on your machine. Start Ollama with an allowed origin:
+
+```bash
+OLLAMA_ORIGINS=https://utsuwa.ai ollama serve
+```
+
+For local development, use:
+
+```bash
+OLLAMA_ORIGINS=http://localhost:5173 ollama serve
+```
 
 ## LM Studio
 
@@ -79,8 +99,10 @@ This starts an OpenAI-compatible API on `http://localhost:1234`.
 1. Open **Settings** (gear icon)
 2. Navigate to the **Character** tab
 3. Enable the LLM toggle, then select **LM Studio** from the provider dropdown
-4. Select a model from the model dropdown (click the refresh icon to reload the list from your server)
-5. Start chatting
+4. Leave the base URL as `http://localhost:1234/v1` unless you changed LM Studio's port
+5. Utsuwa will fetch models from the running LM Studio server. Click the refresh icon if you load a different model.
+6. Select the loaded model from the dropdown
+7. Start chatting
 
 ## Recommended Models
 
@@ -100,14 +122,37 @@ If you're running the LLM server on a different machine or non-default port, ent
 - Remote machine: `http://192.168.1.50:11434`
 - Custom port: `http://localhost:8080`
 
+For Ollama, either `http://localhost:11434` or `http://localhost:11434/v1` works. Utsuwa uses `/api/tags` for model discovery and `/v1/chat/completions` for chat.
+
 ## Troubleshooting
 
 ### "Failed to fetch models"
 
-The LLM server isn't running. Start it:
+The LLM server may not be running or your browser may not be allowed to access it. Start the server:
 
 - Ollama: `ollama serve`
 - LM Studio: Go to the Server tab and click Start Server
+
+If you are using the hosted website with Ollama, restart Ollama with:
+
+```bash
+OLLAMA_ORIGINS=https://utsuwa.ai ollama serve
+```
+
+Then click the refresh icon in Utsuwa's model dropdown.
+
+### "model not found"
+
+The selected model is no longer installed locally, or the local server returned a stale model list.
+
+For Ollama:
+
+```bash
+ollama list
+ollama pull llama3.2
+```
+
+Then select the installed model from Utsuwa's model dropdown.
 
 ### "Connection refused"
 
@@ -131,7 +176,9 @@ Make sure the URL in Utsuwa matches the port your server is using.
 If you're running Utsuwa in a browser and getting CORS errors with Ollama, set the origins environment variable before starting the server:
 
 ```bash
-OLLAMA_ORIGINS=* ollama serve
+OLLAMA_ORIGINS=https://utsuwa.ai ollama serve
 ```
+
+Use `OLLAMA_ORIGINS=http://localhost:5173` for local development, or `OLLAMA_ORIGINS=*` only if you intentionally want to allow any browser origin on your machine.
 
 This isn't needed when using the desktop app.

--- a/src/content/docs/guides/troubleshooting.md
+++ b/src/content/docs/guides/troubleshooting.md
@@ -92,6 +92,18 @@ If the idle animation or expressions aren't working:
 2. **Check VRMA support** - Ensure your model supports VRM animations
 3. **Refresh the page** - Sometimes a reload fixes animation issues
 
+### Local dev page loads but the scene or controls are stuck
+
+If you are developing locally and the `/app` page renders but the model never appears, controls do not respond, or the console shows `Outdated Optimize Dep` or failed dynamic imports, clear Vite's local caches and restart the dev server:
+
+```bash
+rm -rf node_modules/.vite .svelte-kit
+pnpm exec svelte-kit sync
+pnpm exec vite dev --force --host localhost --port 5173
+```
+
+After the page reloads, complete or dismiss the first-run onboarding modal before testing the Settings, Info, or stats controls. The onboarding modal intentionally sits above the scene until setup is finished.
+
 ## Text-to-Speech Issues
 
 ### No audio output
@@ -185,6 +197,14 @@ These usually indicate network problems:
 2. **Verify API endpoint** - Some providers may be down
 3. **CORS issues** - If self-hosting, check CORS configuration
 4. **Firewall/proxy** - Corporate networks may block API calls
+
+For local LLMs, the browser connects directly to your local server:
+
+1. **Ollama running** - Start it with `ollama serve`
+2. **LM Studio running** - Load a model and click Start Server
+3. **Correct base URL** - Use `http://localhost:11434` for Ollama or `http://localhost:1234/v1` for LM Studio
+4. **Hosted website CORS** - For Ollama on `https://utsuwa.ai`, start Ollama with `OLLAMA_ORIGINS=https://utsuwa.ai ollama serve`
+5. **Installed model** - If you see `model not found`, run `ollama list`, pull or load a model, refresh the dropdown, and select an installed model
 
 ### "Page not found" after deployment
 

--- a/src/content/docs/guides/troubleshooting.md
+++ b/src/content/docs/guides/troubleshooting.md
@@ -203,7 +203,7 @@ For local LLMs, the browser connects directly to your local server:
 1. **Ollama running** - Start it with `ollama serve`
 2. **LM Studio running** - Load a model and click Start Server
 3. **Correct base URL** - Use `http://localhost:11434` for Ollama or `http://localhost:1234/v1` for LM Studio
-4. **Hosted website CORS** - For Ollama on `https://utsuwa.ai`, start Ollama with `OLLAMA_ORIGINS=https://utsuwa.ai ollama serve`
+4. **Hosted website CORS** - For Ollama on `https://www.utsuwa.ai`, start Ollama with `OLLAMA_ORIGINS=https://www.utsuwa.ai,https://utsuwa.ai ollama serve`. For Vercel previews, use the exact preview origin from the address bar, such as `OLLAMA_ORIGINS=https://your-preview.vercel.app ollama serve`.
 5. **Installed model** - If you see `model not found`, run `ollama list`, pull or load a model, refresh the dropdown, and select an installed model
 
 ### "Page not found" after deployment

--- a/src/content/docs/guides/troubleshooting.md
+++ b/src/content/docs/guides/troubleshooting.md
@@ -203,7 +203,7 @@ For local LLMs, the browser connects directly to your local server:
 1. **Ollama running** - Start it with `ollama serve`
 2. **LM Studio running** - Load a model and click Start Server
 3. **Correct base URL** - Use `http://localhost:11434` for Ollama or `http://localhost:1234/v1` for LM Studio
-4. **Hosted website CORS** - For Ollama on `https://www.utsuwa.ai`, start Ollama with `OLLAMA_ORIGINS=https://www.utsuwa.ai,https://utsuwa.ai ollama serve`. For Vercel previews, use the exact preview origin from the address bar, such as `OLLAMA_ORIGINS=https://your-preview.vercel.app ollama serve`.
+4. **Hosted website CORS** - For Ollama on `https://www.utsuwa.ai`, start Ollama with `OLLAMA_ORIGINS=https://www.utsuwa.ai,https://utsuwa.ai ollama serve`. For Vercel previews, use the exact preview origin from the address bar, such as `OLLAMA_ORIGINS=https://your-preview.vercel.app ollama serve`. See Ollama's [additional web origins FAQ](https://docs.ollama.com/faq#how-can-i-allow-additional-web-origins-to-access-ollama).
 5. **Installed model** - If you see `model not found`, run `ollama list`, pull or load a model, refresh the dropdown, and select an installed model
 
 ### "Page not found" after deployment

--- a/src/lib/components/onboarding/steps/ServicesStep.svelte
+++ b/src/lib/components/onboarding/steps/ServicesStep.svelte
@@ -26,6 +26,7 @@
 	let llmIsLoading = $state(false);
 	let llmFetchError = $state<string | null>(null);
 	let llmDynamicModels = $state<ModelInfo[] | null>(null);
+	let lastLocalLLMFetchKey = $state('');
 
 	// Use dynamic models if available, otherwise static
 	const llmModels = $derived(llmDynamicModels ?? staticLLMModels);
@@ -65,7 +66,10 @@
 		if (!llmSettings.activeProvider) return false;
 		const provider = getLLMProvider(llmSettings.activeProvider as string);
 		if (!provider) return false;
-		if (provider.isLocal) return true;
+		if (provider.isLocal) {
+			const activeModel = llmSettings.activeModel as string;
+			return !!activeModel && llmModels.some((model) => model.id === activeModel);
+		}
 		if (!provider.requiresApiKey) return true;
 		const config = settingsStore.getProviderConfig(provider.id);
 		return !!config.apiKey;
@@ -91,19 +95,23 @@
 			onSuccess: (models) => {
 				llmIsLoading = false;
 				llmDynamicModels = models;
-				// Auto-select first model if none selected
-				if (!llmSettings.activeModel && models.length > 0) {
+				const currentModel = llmSettings.activeModel as string;
+				const modelExists = models.some((m) => m.id === currentModel);
+				if (!currentModel || !modelExists) {
 					modulesStore.setModuleSetting('consciousness', 'activeModel', models[0].id);
 				}
 			},
-			onError: () => {
+			onError: (error) => {
 				llmIsLoading = false;
-				llmFetchError = 'Using default list';
-				llmDynamicModels = null;
+				llmFetchError = error ?? 'Could not fetch installed models';
+				llmDynamicModels = llmProvider?.isLocal ? [] : null;
 			},
 			onEmpty: () => {
 				llmIsLoading = false;
-				llmDynamicModels = null;
+				llmFetchError = llmProvider?.isLocal
+					? 'No installed models found. Pull a model, then refresh.'
+					: null;
+				llmDynamicModels = llmProvider?.isLocal ? [] : null;
 			},
 			onStale: () => {
 				llmIsLoading = false;
@@ -155,6 +163,21 @@
 	const debouncedFetchLLMModels = debounce(fetchLLMModels, 300);
 	const debouncedFetchTTSModels = debounce(fetchTTSModels, 300);
 
+	$effect(() => {
+		if (!llmProvider?.isLocal) {
+			lastLocalLLMFetchKey = '';
+			return;
+		}
+
+		const baseUrl = settingsStore.getProviderConfig(llmProvider.id).baseUrl ?? llmProvider.defaultBaseUrl ?? '';
+		const fetchKey = `${llmProvider.id}:${baseUrl}`;
+
+		if (fetchKey !== lastLocalLLMFetchKey) {
+			lastLocalLLMFetchKey = fetchKey;
+			debouncedFetchLLMModels();
+		}
+	});
+
 	// Handlers
 	function handleLLMProviderChange(providerId: string) {
 		modulesStore.setModuleSetting('consciousness', 'activeProvider', providerId);
@@ -171,7 +194,7 @@
 			llmDynamicModels = cached;
 		}
 
-		if (provider?.models?.length) {
+		if (provider && !provider.isLocal && provider.models?.length) {
 			modulesStore.setModuleSetting('consciousness', 'activeModel', provider.models[0].id);
 		}
 		// Mark local providers as added immediately (they don't need API keys)
@@ -204,6 +227,7 @@
 	function handleLLMBaseUrlChange(baseUrl: string) {
 		if (llmProvider) {
 			settingsStore.setProviderConfig(llmProvider.id, { baseUrl });
+			llmFetchError = null;
 		}
 	}
 
@@ -306,7 +330,7 @@
 			/>
 		{/if}
 
-		{#if llmSettings.activeProvider && !llmProvider?.isLocal}
+		{#if llmSettings.activeProvider}
 			<ModelDropdown
 				models={llmModels}
 				value={llmSettings.activeModel as string}
@@ -319,14 +343,11 @@
 			/>
 		{/if}
 
-		{#if llmProvider?.isLocal}
-			<input
-				type="text"
-				class="api-key-input"
-				placeholder="Model name (e.g., llama3.2:latest)"
-				value={llmSettings.activeModel as string ?? ''}
-				oninput={(e) => handleLLMModelChange(e.currentTarget.value)}
-			/>
+		{#if llmProvider?.isLocal && llmFetchError}
+			<p class="provider-note error">
+				<Icon name="alert-circle" size={14} />
+				{llmFetchError}
+			</p>
 		{/if}
 
 		{#if llmProvider?.isLocal}
@@ -336,6 +357,7 @@
 				placeholder={llmProvider.defaultBaseUrl || 'http://localhost:11434/v1/'}
 				value={settingsStore.getProviderConfig(llmProvider.id).baseUrl ?? ''}
 				oninput={(e) => handleLLMBaseUrlChange(e.currentTarget.value)}
+				onblur={fetchLLMModels}
 			/>
 			<p class="provider-note">
 				<Icon name="check-circle" size={14} />
@@ -679,6 +701,10 @@
 		margin: 0;
 		font-size: 0.75rem;
 		color: var(--color-success);
+	}
+
+	.provider-note.error {
+		color: var(--color-error);
 	}
 
 	.skip-note {

--- a/src/lib/services/chat/client-chat.ts
+++ b/src/lib/services/chat/client-chat.ts
@@ -1,4 +1,9 @@
 import type { LLMProvider } from '$lib/types';
+import {
+	getChatBaseUrl,
+	getLocalProviderConnectionHint,
+	isLocalLLMProvider
+} from '$lib/services/providers/local-endpoints';
 
 interface ChatMessage {
 	role: 'system' | 'user' | 'assistant';
@@ -25,11 +30,9 @@ const PROVIDER_BASE_URLS: Partial<Record<LLMProvider, string>> = {
 	lmstudio: 'http://localhost:1234/v1/'
 };
 
-const LOCAL_PROVIDERS: LLMProvider[] = ['ollama', 'lmstudio'];
-
 /**
  * Stream chat completions directly from provider APIs.
- * Used in Tauri builds where SvelteKit server routes aren't available.
+ * Used for local providers and Tauri builds where SvelteKit server routes aren't available.
  */
 export async function streamChatDirect(
 	options: ChatOptions,
@@ -39,13 +42,15 @@ export async function streamChatDirect(
 ): Promise<void> {
 	const { messages, provider, model, apiKey, baseURL, systemPrompt } = options;
 
-	const isLocal = LOCAL_PROVIDERS.includes(provider);
+	const isLocal = isLocalLLMProvider(provider);
 	if (!apiKey && !isLocal) {
 		onError('API key required');
 		return;
 	}
 
-	const providerBaseURL = baseURL || PROVIDER_BASE_URLS[provider];
+	const providerBaseURL = isLocal
+		? getChatBaseUrl(provider, baseURL)
+		: baseURL || PROVIDER_BASE_URLS[provider];
 	if (!providerBaseURL) {
 		onError(`Unknown provider: ${provider}`);
 		return;
@@ -96,7 +101,7 @@ export async function streamChatDirect(
 			const msg =
 				(errorData as { error?: { message?: string } })?.error?.message ||
 				`Provider error (${response.status})`;
-			onError(msg);
+			onError(isLocal && response.status === 404 ? `${msg}. Pull or select an installed model.` : msg);
 			return;
 		}
 
@@ -141,7 +146,8 @@ export async function streamChatDirect(
 
 		onDone();
 	} catch (err) {
-		const msg = err instanceof Error ? err.message : 'Failed to connect to provider';
+		const rawMessage = err instanceof Error ? err.message : 'Failed to connect to provider';
+		const msg = isLocal ? getLocalProviderConnectionHint(provider, providerBaseURL) : rawMessage;
 		onError(msg);
 	}
 }

--- a/src/lib/services/chat/client-chat.ts
+++ b/src/lib/services/chat/client-chat.ts
@@ -30,6 +30,10 @@ const PROVIDER_BASE_URLS: Partial<Record<LLMProvider, string>> = {
 	lmstudio: 'http://localhost:1234/v1/'
 };
 
+function getCurrentSiteOrigin(): string | undefined {
+	return typeof window !== 'undefined' ? window.location.origin : undefined;
+}
+
 /**
  * Stream chat completions directly from provider APIs.
  * Used for local providers and Tauri builds where SvelteKit server routes aren't available.
@@ -147,7 +151,9 @@ export async function streamChatDirect(
 		onDone();
 	} catch (err) {
 		const rawMessage = err instanceof Error ? err.message : 'Failed to connect to provider';
-		const msg = isLocal ? getLocalProviderConnectionHint(provider, providerBaseURL) : rawMessage;
+		const msg = isLocal
+			? getLocalProviderConnectionHint(provider, providerBaseURL, getCurrentSiteOrigin())
+			: rawMessage;
 		onError(msg);
 	}
 }

--- a/src/lib/services/providers/client-models.ts
+++ b/src/lib/services/providers/client-models.ts
@@ -30,6 +30,10 @@ const MODEL_FILTERS: Record<string, RegExp> = {
 	google: /^gemini-/
 };
 
+function getCurrentSiteOrigin(): string | undefined {
+	return typeof window !== 'undefined' ? window.location.origin : undefined;
+}
+
 function normalizeModelName(id: string, providerId: string): string {
 	let name = id;
 	if (providerId === 'google' && name.startsWith('models/')) {
@@ -166,7 +170,7 @@ export async function fetchModelsDirect(
 	} catch (error) {
 		const message =
 			isLocalLLMProvider(providerId)
-				? getLocalProviderConnectionHint(providerId, cleanBaseUrl)
+				? getLocalProviderConnectionHint(providerId, cleanBaseUrl, getCurrentSiteOrigin())
 				: error instanceof Error ? error.message : 'Unknown error';
 		return { models: [], error: message };
 	}

--- a/src/lib/services/providers/client-models.ts
+++ b/src/lib/services/providers/client-models.ts
@@ -1,4 +1,9 @@
 import type { LLMProvider } from '$lib/types';
+import {
+	getLocalProviderConnectionHint,
+	getModelsBaseUrl,
+	isLocalLLMProvider
+} from './local-endpoints';
 
 interface ModelInfo {
 	id: string;
@@ -52,7 +57,10 @@ export async function fetchModelsDirect(
 	apiKey?: string,
 	baseUrl?: string
 ): Promise<{ models: ModelInfo[]; error?: string }> {
-	const cleanBaseUrl = (baseUrl || DEFAULT_BASE_URLS[providerId] || '').replace(/\/+$/, '');
+	const cleanBaseUrl =
+		providerId === 'ollama' || providerId === 'lmstudio'
+			? getModelsBaseUrl(providerId, baseUrl)
+			: (baseUrl || DEFAULT_BASE_URLS[providerId] || '').replace(/\/+$/, '');
 
 	try {
 		let models: ModelInfo[] = [];
@@ -156,7 +164,10 @@ export async function fetchModelsDirect(
 		const filtered = filter ? models.filter((m) => filter.test(m.id)) : models;
 		return { models: filtered };
 	} catch (error) {
-		const message = error instanceof Error ? error.message : 'Unknown error';
+		const message =
+			isLocalLLMProvider(providerId)
+				? getLocalProviderConnectionHint(providerId, cleanBaseUrl)
+				: error instanceof Error ? error.message : 'Unknown error';
 		return { models: [], error: message };
 	}
 }

--- a/src/lib/services/providers/local-endpoints.test.ts
+++ b/src/lib/services/providers/local-endpoints.test.ts
@@ -33,5 +33,13 @@ test('normalizes LM Studio root URL to OpenAI-compatible v1 URL', () => {
 
 test('provides local provider troubleshooting hints', () => {
 	assert.match(getLocalProviderConnectionHint('ollama', 'http://localhost:11434'), /ollama serve/);
+	assert.match(
+		getLocalProviderConnectionHint(
+			'ollama',
+			'http://localhost:11434',
+			'https://utsuwa-git-fix-ollama-local-provider.vercel.app'
+		),
+		/OLLAMA_ORIGINS="https:\/\/utsuwa-git-fix-ollama-local-provider\.vercel\.app"/
+	);
 	assert.match(getLocalProviderConnectionHint('lmstudio', 'http://localhost:1234/v1'), /Start Server/);
 });

--- a/src/lib/services/providers/local-endpoints.test.ts
+++ b/src/lib/services/providers/local-endpoints.test.ts
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+	getChatBaseUrl,
+	getModelsBaseUrl,
+	isLocalLLMProvider,
+	getLocalProviderConnectionHint
+} from './local-endpoints.ts';
+
+test('identifies local LLM providers', () => {
+	assert.equal(isLocalLLMProvider('ollama'), true);
+	assert.equal(isLocalLLMProvider('lmstudio'), true);
+	assert.equal(isLocalLLMProvider('openai'), false);
+});
+
+test('normalizes Ollama root URL to OpenAI-compatible chat URL', () => {
+	assert.equal(getChatBaseUrl('ollama', 'http://localhost:11434'), 'http://localhost:11434/v1');
+	assert.equal(getChatBaseUrl('ollama', 'http://localhost:11434/'), 'http://localhost:11434/v1');
+	assert.equal(getChatBaseUrl('ollama', 'http://localhost:11434/v1'), 'http://localhost:11434/v1');
+});
+
+test('normalizes Ollama model-list URL to the Ollama API root', () => {
+	assert.equal(getModelsBaseUrl('ollama', 'http://localhost:11434/v1'), 'http://localhost:11434');
+	assert.equal(getModelsBaseUrl('ollama'), 'http://localhost:11434');
+});
+
+test('normalizes LM Studio root URL to OpenAI-compatible v1 URL', () => {
+	assert.equal(getChatBaseUrl('lmstudio', 'http://localhost:1234'), 'http://localhost:1234/v1');
+	assert.equal(getModelsBaseUrl('lmstudio', 'http://localhost:1234'), 'http://localhost:1234/v1');
+	assert.equal(getChatBaseUrl('lmstudio', 'http://localhost:1234/v1'), 'http://localhost:1234/v1');
+});
+
+test('provides local provider troubleshooting hints', () => {
+	assert.match(getLocalProviderConnectionHint('ollama', 'http://localhost:11434'), /ollama serve/);
+	assert.match(getLocalProviderConnectionHint('lmstudio', 'http://localhost:1234/v1'), /Start Server/);
+});

--- a/src/lib/services/providers/local-endpoints.test.ts
+++ b/src/lib/services/providers/local-endpoints.test.ts
@@ -41,5 +41,9 @@ test('provides local provider troubleshooting hints', () => {
 		),
 		/OLLAMA_ORIGINS="https:\/\/utsuwa-git-fix-ollama-local-provider\.vercel\.app"/
 	);
+	assert.match(
+		getLocalProviderConnectionHint('ollama', 'http://localhost:11434'),
+		/docs\.ollama\.com\/faq#how-can-i-allow-additional-web-origins-to-access-ollama/
+	);
 	assert.match(getLocalProviderConnectionHint('lmstudio', 'http://localhost:1234/v1'), /Start Server/);
 });

--- a/src/lib/services/providers/local-endpoints.ts
+++ b/src/lib/services/providers/local-endpoints.ts
@@ -46,11 +46,18 @@ export function getChatBaseUrl(providerId: string, baseUrl?: string): string {
 	return cleanUrl;
 }
 
-export function getLocalProviderConnectionHint(providerId: string, baseUrl?: string): string {
+export function getLocalProviderConnectionHint(
+	providerId: string,
+	baseUrl?: string,
+	siteOrigin?: string
+): string {
 	const chatBaseUrl = getChatBaseUrl(providerId, baseUrl);
 
 	if (providerId === 'ollama') {
-		return `Could not reach Ollama at ${chatBaseUrl}. Make sure Ollama is running with "ollama serve", the model is pulled with "ollama pull <model>", and browser users allow this site's origin with OLLAMA_ORIGINS.`;
+		const originHint = siteOrigin
+			? ` For this site, restart Ollama with OLLAMA_ORIGINS="${siteOrigin}" ollama serve.`
+			: ` Set OLLAMA_ORIGINS to this site's origin before starting Ollama.`;
+		return `Could not reach Ollama at ${chatBaseUrl}. Make sure Ollama is running with "ollama serve", the model is pulled with "ollama pull <model>", and browser users allow this site's origin with OLLAMA_ORIGINS.${originHint}`;
 	}
 
 	if (providerId === 'lmstudio') {

--- a/src/lib/services/providers/local-endpoints.ts
+++ b/src/lib/services/providers/local-endpoints.ts
@@ -1,0 +1,61 @@
+const LOCAL_LLM_PROVIDERS = new Set(['ollama', 'lmstudio']);
+
+const DEFAULT_BASE_URLS: Record<string, string> = {
+	ollama: 'http://localhost:11434',
+	lmstudio: 'http://localhost:1234/v1'
+};
+
+function trimTrailingSlashes(url: string): string {
+	return url.replace(/\/+$/, '');
+}
+
+function stripOpenAIPath(url: string): string {
+	return trimTrailingSlashes(url).replace(/\/v1$/, '');
+}
+
+function ensureOpenAIPath(url: string): string {
+	const cleanUrl = trimTrailingSlashes(url);
+	return cleanUrl.endsWith('/v1') ? cleanUrl : `${cleanUrl}/v1`;
+}
+
+export function isLocalLLMProvider(providerId: string): boolean {
+	return LOCAL_LLM_PROVIDERS.has(providerId);
+}
+
+export function getModelsBaseUrl(providerId: string, baseUrl?: string): string {
+	const cleanUrl = trimTrailingSlashes(baseUrl || DEFAULT_BASE_URLS[providerId] || '');
+
+	if (providerId === 'ollama') {
+		return stripOpenAIPath(cleanUrl);
+	}
+
+	if (providerId === 'lmstudio') {
+		return ensureOpenAIPath(cleanUrl);
+	}
+
+	return cleanUrl;
+}
+
+export function getChatBaseUrl(providerId: string, baseUrl?: string): string {
+	const cleanUrl = trimTrailingSlashes(baseUrl || DEFAULT_BASE_URLS[providerId] || '');
+
+	if (providerId === 'ollama' || providerId === 'lmstudio') {
+		return ensureOpenAIPath(cleanUrl);
+	}
+
+	return cleanUrl;
+}
+
+export function getLocalProviderConnectionHint(providerId: string, baseUrl?: string): string {
+	const chatBaseUrl = getChatBaseUrl(providerId, baseUrl);
+
+	if (providerId === 'ollama') {
+		return `Could not reach Ollama at ${chatBaseUrl}. Make sure Ollama is running with "ollama serve", the model is pulled with "ollama pull <model>", and browser users allow this site's origin with OLLAMA_ORIGINS.`;
+	}
+
+	if (providerId === 'lmstudio') {
+		return `Could not reach LM Studio at ${chatBaseUrl}. Open LM Studio, go to the Developer or Server tab, load a model, and click Start Server.`;
+	}
+
+	return `Could not reach local provider at ${chatBaseUrl}. Make sure the local server is running and reachable from this device.`;
+}

--- a/src/lib/services/providers/local-endpoints.ts
+++ b/src/lib/services/providers/local-endpoints.ts
@@ -5,6 +5,9 @@ const DEFAULT_BASE_URLS: Record<string, string> = {
 	lmstudio: 'http://localhost:1234/v1'
 };
 
+const OLLAMA_ORIGINS_DOC_URL =
+	'https://docs.ollama.com/faq#how-can-i-allow-additional-web-origins-to-access-ollama';
+
 function trimTrailingSlashes(url: string): string {
 	return url.replace(/\/+$/, '');
 }
@@ -57,7 +60,7 @@ export function getLocalProviderConnectionHint(
 		const originHint = siteOrigin
 			? ` For this site, restart Ollama with OLLAMA_ORIGINS="${siteOrigin}" ollama serve.`
 			: ` Set OLLAMA_ORIGINS to this site's origin before starting Ollama.`;
-		return `Could not reach Ollama at ${chatBaseUrl}. Make sure Ollama is running with "ollama serve", the model is pulled with "ollama pull <model>", and browser users allow this site's origin with OLLAMA_ORIGINS.${originHint}`;
+		return `Could not reach Ollama at ${chatBaseUrl}. Make sure Ollama is running with "ollama serve", the model is pulled with "ollama pull <model>", and browser users allow this site's origin with OLLAMA_ORIGINS.${originHint} More help: ${OLLAMA_ORIGINS_DOC_URL}`;
 	}
 
 	if (providerId === 'lmstudio') {

--- a/src/lib/services/providers/model-fetcher.ts
+++ b/src/lib/services/providers/model-fetcher.ts
@@ -1,5 +1,6 @@
 import { isTauri } from '$lib/services/platform';
 import { fetchModelsDirect } from './client-models';
+import { isLocalLLMProvider } from './local-endpoints';
 
 export interface ModelInfo {
 	id: string;
@@ -19,8 +20,9 @@ export async function fetchProviderModels(
 	apiKey: string,
 	baseUrl?: string
 ): Promise<FetchModelsResult> {
-	// Tauri production builds don't have server routes — fetch directly
-	if (isTauri()) {
+	// Local providers must be fetched from the user's device, not the deployed server.
+	// Tauri production builds also don't have server routes.
+	if (isTauri() || isLocalLLMProvider(providerId)) {
 		return fetchModelsDirect(providerId, apiKey, baseUrl);
 	}
 

--- a/src/lib/services/providers/registry.test.ts
+++ b/src/lib/services/providers/registry.test.ts
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { LLM_PROVIDERS } from './registry.ts';
+
+test('local LLM providers rely on discovered installed models', () => {
+	const localProviders = LLM_PROVIDERS.filter((provider) => provider.isLocal);
+
+	assert.ok(localProviders.length > 0);
+	for (const provider of localProviders) {
+		assert.deepEqual(provider.models ?? [], [], `${provider.name} should not expose static model choices`);
+	}
+});

--- a/src/lib/services/providers/registry.ts
+++ b/src/lib/services/providers/registry.ts
@@ -66,7 +66,7 @@ export const LLM_PROVIDERS: ProviderMetadata[] = [
 		requiresApiKey: true,
 		defaultBaseUrl: 'https://api.x.ai/v1/'
 	},
-	// Local LLM - keep example models as hints
+	// Local LLMs discover installed models from the user's running local server.
 	{
 		id: 'ollama',
 		name: 'Ollama',
@@ -75,14 +75,8 @@ export const LLM_PROVIDERS: ProviderMetadata[] = [
 		icon: '🦙',
 		requiresApiKey: false,
 		isLocal: true,
-		defaultBaseUrl: 'http://localhost:11434/v1/',
-		models: [
-			{ id: 'llama3.2', name: 'Llama 3.2' },
-			{ id: 'llama3.1', name: 'Llama 3.1' },
-			{ id: 'mistral', name: 'Mistral' },
-			{ id: 'codellama', name: 'Code Llama' },
-			{ id: 'phi3', name: 'Phi-3' }
-		]
+		defaultBaseUrl: 'http://localhost:11434',
+		models: []
 	},
 	{
 		id: 'lmstudio',
@@ -176,4 +170,3 @@ export function getLLMProvider(id: string): ProviderMetadata | undefined {
 export function getTTSProvider(id: string): ProviderMetadata | undefined {
 	return TTS_PROVIDERS.find((p) => p.id === id);
 }
-

--- a/src/lib/services/providers/use-model-fetch.ts
+++ b/src/lib/services/providers/use-model-fetch.ts
@@ -36,7 +36,7 @@ export interface FetchModelsOptions {
 	getCurrentProviderId: () => string | undefined;
 	onStart: () => void;
 	onSuccess: (models: ModelInfo[]) => void;
-	onError: () => void;
+	onError: (error?: string) => void;
 	onEmpty: () => void;
 	onStale: () => void;
 }
@@ -58,7 +58,7 @@ export async function fetchModels(options: FetchModelsOptions): Promise<void> {
 		onStale
 	} = options;
 
-	if (!providerId || isLocal || !apiKey) return;
+	if (!providerId || (!isLocal && !apiKey)) return;
 
 	onStart();
 
@@ -71,7 +71,7 @@ export async function fetchModels(options: FetchModelsOptions): Promise<void> {
 	}
 
 	if (result.error) {
-		onError();
+		onError(result.error);
 	} else if (result.models.length > 0) {
 		settingsStore.setCachedModels(providerId, result.models);
 		onSuccess(result.models);

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -88,12 +88,13 @@ function createSettingsStore() {
 	// Provider configuration
 	function setProviderConfig(providerId: string, config: Partial<ProviderConfig>) {
 		const oldApiKey = providerConfigs[providerId]?.apiKey;
+		const oldBaseUrl = providerConfigs[providerId]?.baseUrl;
 		providerConfigs[providerId] = {
 			...providerConfigs[providerId],
 			...config
 		};
-		// Invalidate model cache if API key changed (user may have switched accounts)
-		if (config.apiKey && config.apiKey !== oldApiKey) {
+		// Invalidate model cache if credentials or endpoint changed.
+		if ((config.apiKey && config.apiKey !== oldApiKey) || (config.baseUrl !== undefined && config.baseUrl !== oldBaseUrl)) {
 			delete providerConfigs[providerId].cachedModels;
 			delete providerConfigs[providerId].modelsFetchedAt;
 		}

--- a/src/routes/api/chat/+server.ts
+++ b/src/routes/api/chat/+server.ts
@@ -1,6 +1,7 @@
 import { streamText } from '@xsai/stream-text';
 import type { RequestHandler } from './$types';
 import type { LLMProvider } from '$lib/types';
+import { getChatBaseUrl } from '$lib/services/providers/local-endpoints';
 
 // Provider base URLs
 const PROVIDER_BASE_URLS: Partial<Record<LLMProvider, string>> = {
@@ -49,6 +50,8 @@ export const POST: RequestHandler = async ({ request }) => {
 		if (typedProvider === 'anthropic') {
 			providerBaseURL = providerBaseURL || PROVIDER_BASE_URLS.anthropic;
 			headers['anthropic-dangerous-direct-browser-access'] = 'true';
+		} else if (isLocalProvider) {
+			providerBaseURL = getChatBaseUrl(typedProvider, providerBaseURL);
 		} else {
 			// Use default base URL for provider
 			providerBaseURL = providerBaseURL || PROVIDER_BASE_URLS[typedProvider];

--- a/src/routes/api/providers/models/+server.ts
+++ b/src/routes/api/providers/models/+server.ts
@@ -1,5 +1,6 @@
 import type { RequestHandler } from './$types';
 import type { LLMProvider } from '$lib/types';
+import { getModelsBaseUrl } from '$lib/services/providers/local-endpoints';
 
 interface ModelInfo {
 	id: string;
@@ -197,7 +198,10 @@ export const POST: RequestHandler = async ({ request }) => {
 			baseUrl || DEFAULT_BASE_URLS[providerId as LLMProvider] || '';
 
 		// Remove trailing slash for consistency
-		const cleanBaseUrl = effectiveBaseUrl.replace(/\/+$/, '');
+		const cleanBaseUrl =
+			providerId === 'ollama' || providerId === 'lmstudio'
+				? getModelsBaseUrl(providerId, effectiveBaseUrl)
+				: effectiveBaseUrl.replace(/\/+$/, '');
 
 		let models: ModelInfo[] = [];
 

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -253,7 +253,9 @@
 			let fullContent = '';
 			const selectedModel = model || providerMeta?.models?.[0]?.id || '';
 
-			if (isTauri()) {
+			const shouldUseDirectChat = isTauri() || !!providerMeta?.isLocal;
+
+			if (shouldUseDirectChat) {
 				await new Promise<void>((resolve, reject) => {
 					streamChatDirect(
 						{

--- a/src/routes/app/settings/persona/+page.svelte
+++ b/src/routes/app/settings/persona/+page.svelte
@@ -96,6 +96,7 @@
 	let llmIsLoading = $state(false);
 	let llmFetchError = $state<string | null>(null);
 	let llmDynamicModels = $state<ModelInfo[] | null>(null);
+	let lastLocalLLMFetchKey = $state('');
 
 	const staticLLMModels = $derived.by(() => {
 		const providerId = consciousnessSettings.activeProvider as string;
@@ -173,14 +174,17 @@
 					modulesStore.setModuleSetting('consciousness', 'activeModel', models[0].id);
 				}
 			},
-			onError: () => {
+			onError: (error) => {
 				llmIsLoading = false;
-				llmFetchError = 'Using default list';
-				llmDynamicModels = null;
+				llmFetchError = error ?? 'Could not fetch installed models';
+				llmDynamicModels = provider.isLocal ? [] : null;
 			},
 			onEmpty: () => {
 				llmIsLoading = false;
-				llmDynamicModels = null;
+				llmFetchError = provider.isLocal
+					? 'No installed models found. Pull a model, then refresh.'
+					: null;
+				llmDynamicModels = provider.isLocal ? [] : null;
 			},
 			onStale: () => {
 				llmIsLoading = false;
@@ -236,6 +240,23 @@
 	const debouncedFetchLLMModels = debounce(fetchLLMModels, 300);
 	const debouncedFetchTTSModels = debounce(fetchTTSModels, 300);
 
+	$effect(() => {
+		const providerId = consciousnessSettings.activeProvider as string;
+		const provider = providerId ? getLLMProvider(providerId) : null;
+		if (!provider?.isLocal) {
+			lastLocalLLMFetchKey = '';
+			return;
+		}
+
+		const baseUrl = settingsStore.getProviderConfig(provider.id).baseUrl ?? provider.defaultBaseUrl ?? '';
+		const fetchKey = `${provider.id}:${baseUrl}`;
+
+		if (fetchKey !== lastLocalLLMFetchKey) {
+			lastLocalLLMFetchKey = fetchKey;
+			debouncedFetchLLMModels();
+		}
+	});
+
 	// Load form values from store when character is ready
 	$effect(() => {
 		if (characterStore.isReady) {
@@ -268,7 +289,7 @@
 			llmDynamicModels = cached;
 		}
 
-		if (provider?.models?.length) {
+		if (provider && !provider.isLocal && provider.models?.length) {
 			modulesStore.setModuleSetting('consciousness', 'activeModel', provider.models[0].id);
 		}
 		// Mark local providers as added immediately (they don't need API keys)
@@ -279,6 +300,11 @@
 
 	function handleLLMModelChange(modelId: string) {
 		modulesStore.setModuleSetting('consciousness', 'activeModel', modelId);
+	}
+
+	function handleLLMBaseUrlChange(providerId: string, baseUrl: string) {
+		settingsStore.setProviderConfig(providerId, { baseUrl });
+		llmFetchError = null;
 	}
 
 	function handleTTSProviderChange(providerId: string) {
@@ -516,39 +542,35 @@
 
 								{#if consciousnessSettings.activeProvider}
 									{@const provider = getLLMProvider(consciousnessSettings.activeProvider as string)}
-									{#if !provider?.isLocal}
-										<ModelDropdown
-											models={llmModels}
-											value={consciousnessSettings.activeModel as string}
-											onSelect={handleLLMModelChange}
-											placeholder="Select model..."
-											isLoading={llmIsLoading}
-											onRefresh={llmHasApiKey ? fetchLLMModels : undefined}
-											disabled={!llmHasApiKey}
-											disabledMessage="Enter API key first"
-										/>
-									{/if}
+									<ModelDropdown
+										models={llmModels}
+										value={consciousnessSettings.activeModel as string}
+										onSelect={handleLLMModelChange}
+										placeholder="Select model..."
+										isLoading={llmIsLoading}
+										onRefresh={llmHasApiKey ? fetchLLMModels : undefined}
+										disabled={!llmHasApiKey}
+										disabledMessage="Enter API key first"
+									/>
 								{/if}
 
 								{#if consciousnessSettings.activeProvider}
 									{@const provider = getLLMProvider(consciousnessSettings.activeProvider as string)}
 									{#if provider?.isLocal}
-										<div class="api-key-row">
-											<input
-												type="text"
-												class="api-key-input"
-												placeholder="Model name (e.g., llama3.2:latest)"
-												value={consciousnessSettings.activeModel as string ?? ''}
-												onchange={(e) => handleLLMModelChange(e.currentTarget.value)}
-											/>
-										</div>
+										{#if llmFetchError}
+											<p class="provider-note error">
+												<Icon name="alert-circle" size={14} />
+												{llmFetchError}
+											</p>
+										{/if}
 										<div class="api-key-row">
 											<input
 												type="text"
 												class="api-key-input"
 												placeholder={provider.defaultBaseUrl || 'http://localhost:11434/v1/'}
 												value={settingsStore.getProviderConfig(provider.id).baseUrl ?? ''}
-												onchange={(e) => settingsStore.setProviderConfig(provider.id, { baseUrl: e.currentTarget.value })}
+												oninput={(e) => handleLLMBaseUrlChange(provider.id, e.currentTarget.value)}
+												onblur={fetchLLMModels}
 											/>
 										</div>
 									{/if}
@@ -2522,6 +2544,19 @@
 	.api-key-row {
 		display: flex;
 		gap: 0.5rem;
+	}
+
+	.provider-note {
+		display: flex;
+		align-items: center;
+		gap: 0.375rem;
+		margin: 0;
+		font-size: 0.75rem;
+		color: var(--text-tertiary);
+	}
+
+	.provider-note.error {
+		color: var(--color-error);
 	}
 
 	.api-key-input {

--- a/src/routes/overlay/+page.svelte
+++ b/src/routes/overlay/+page.svelte
@@ -250,8 +250,10 @@
 			let fullContent = '';
 			const selectedModel = model || providerMeta?.models?.[0]?.id || '';
 
-			if (isTauri()) {
-				// Tauri: call provider APIs directly (no server routes in static builds)
+			const shouldUseDirectChat = isTauri() || !!providerMeta?.isLocal;
+
+			if (shouldUseDirectChat) {
+				// Tauri and local providers call provider APIs directly.
 				await new Promise<void>((resolve, reject) => {
 					streamChatDirect(
 						{
@@ -268,7 +270,7 @@
 					);
 				});
 			} else {
-				// Web: use SvelteKit server route
+				// Cloud providers in web builds use the SvelteKit server route.
 				const response = await fetch('/api/chat', {
 					method: 'POST',
 					headers: { 'Content-Type': 'application/json' },

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -3,13 +3,13 @@ import adapterStatic from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 import { mdsvex } from 'mdsvex';
 import rehypeSlug from 'rehype-slug';
-import { createHighlighter } from 'shiki';
+import { createHighlighter } from 'shiki/bundle/web';
 
 const isTauri = !!process.env.TAURI_ENV_PLATFORM;
 
 const highlighter = await createHighlighter({
 	themes: ['github-light', 'github-dark'],
-	langs: ['javascript', 'typescript', 'bash', 'json', 'svelte', 'html', 'css', 'markdown']
+	langs: ['js', 'ts', 'bash', 'json', 'svelte', 'html', 'css', 'md']
 });
 
 /** @type {import('@sveltejs/kit').Config} */


### PR DESCRIPTION
## Summary

Fixes #16.

This updates local LLM support so Ollama and LM Studio use models discovered from the user's local server instead of relying on typed/default model names. It also improves Ollama troubleshooting for browser users by explaining the required `OLLAMA_ORIGINS` setup and linking to Ollama's official web origins FAQ.

## What changed

- Discover installed local models from Ollama/LM Studio and show them in the model dropdown
- Remove the manual local model-name flow for local providers
- Route local provider model fetching/chat through the browser so hosted web builds can reach the user's local server
- Improve Ollama connection errors with origin-specific guidance and the official Ollama FAQ link
- Update local LLM and troubleshooting docs
- Add focused tests for local endpoint normalization and provider registry behavior

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm build`
- Tested locally with Ollama
- Tested Vercel preview with `OLLAMA_ORIGINS` configured for the preview origin

## Notes

Browser-based Ollama usage still requires the user to allow the current website origin in Ollama via `OLLAMA_ORIGINS`. This is expected Ollama behavior, and the app now explains that clearly.
