### PR TITLE
Prepare v0.2.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.5] - 2026-05-29
+
+### Fixed
+- Fixed browser-based Ollama and LM Studio local model discovery by fetching installed local models from the user's device instead of relying on typed/default model names.
+- Fixed Ollama `model not found` confusion by requiring users to select an installed model from the discovered model dropdown.
+- Improved Ollama hosted-site CORS troubleshooting with origin-specific `OLLAMA_ORIGINS` guidance and a link to Ollama's official web origins FAQ.
+- Fixed local development route rendering hangs caused by the Shiki highlighter bundle used in SvelteKit routes.
+
+### Changed
+- Updated local LLM onboarding and settings to use discovered local models for Ollama and LM Studio.
+- Updated local LLM setup and troubleshooting documentation.
+- Removed the stale local LLM blog article.
+
 ## [Unreleased] - Desktop App
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "utsuwa",
-	"version": "0.2.4",
+	"version": "0.2.5",
 	"packageManager": "pnpm@10.28.2",
 	"description": "An open-source VRM avatar companion app with AI chat, voice, memory, and relationship mechanics",
 	"author": "Ordinary Company Group LLC",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4200,7 +4200,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utsuwa"
-version = "0.2.3"
+version = "0.2.5"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utsuwa"
-version = "0.2.3"
+version = "0.2.5"
 description = "Open Source AI Soul Vessel - VRM Avatar Companion"
 authors = ["Ordinary Company Group LLC"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Utsuwa",
-  "version": "0.2.3",
+  "version": "0.2.5",
   "identifier": "com.utsuwa.app",
   "build": {
     "beforeBuildCommand": "npm run build",


### PR DESCRIPTION
## Summary

Prepares the v0.2.5 release after the local LLM/Ollama fix.

## What changed

- Bumps package version to `0.2.5`
- Bumps Tauri app/crate versions to `0.2.5`
- Adds v0.2.5 changelog notes for the local LLM fix and documentation updates

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `pnpm tauri build`

## Release artifact built locally

- `src-tauri/target/release/bundle/dmg/Utsuwa_0.2.5_aarch64.dmg`

After this merges, tag `v0.2.5` from `main` and create the GitHub Release with the DMG attached.
