### PR TITLE
Add dev log and update roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@
 - **3D Speech Bubbles**: Chat responses appear as bubbles that track the model's head in 3D space
 - **Chat Interface**: Bottom-centered input bar with streaming responses
 - **Voice Input**: Speech-to-text via Groq (Whisper) or Web Speech API with real-time audio visualization
-- **LLM Integration**: Support for 7 LLM providers including OpenAI, Anthropic, Google, and local options
+- **LLM Integration**: Support for 7 LLM providers including OpenAI, Anthropic, Google, xAI, DeepSeek, Ollama, and LM Studio
+- **Local Model Discovery**: Ollama and LM Studio discover installed local models directly from your device
 - **Text-to-Speech**: Support for ElevenLabs and OpenAI TTS
 - **Lip-sync**: Audio-driven mouth animation synced to TTS playback
 - **Animations**: VRMA-based idle and talking animations with automatic blinking
@@ -140,10 +141,11 @@ pnpm tauri dev
 #### Configuration
 
 1. Click the **Settings** (gear icon) in the sidebar
-2. Navigate to **LLM Providers** to configure your chat provider:
-   - Select a provider and enter your API key
-   - Or use a local server like Ollama or LM Studio
-3. Navigate to **TTS Providers** to configure text-to-speech (optional):
+2. Navigate to **Settings > Character** to configure your chat provider:
+   - Enable Chat (LLM)
+   - Select a cloud provider and enter your API key
+   - Or select a local server like Ollama or LM Studio and choose an installed model from the discovered model dropdown
+3. Configure text-to-speech in the same settings area (optional):
    - Select a TTS provider
    - Enter your API key
    - Configure voice settings
@@ -233,14 +235,11 @@ pnpm tauri build  # Build desktop app installer
 
 ### In Progress / Planned
 
-- [ ] **Companion Gender System** - Gender selection with male/female specific animations and behaviors
+- [ ] **File, Image, and Video Uploads** - Add support for attaching files, images, and videos for multimodal LLM workflows and providers that can use richer context or web-aware tools
+- [ ] **OpenAI-Compatible Models** - Add a configurable option for OpenAI-compatible model endpoints beyond the currently listed providers
 - [ ] **Multi-provider STT** - Support for additional speech-to-text providers beyond Groq and Web Speech API
-- [ ] **Enhanced User Controls** - More granular control over companion behavior and responses
-- [ ] **Custom Lighting Controls** - Adjust 3D scene lighting, environment, and atmosphere
-- [ ] **LLM-Controlled Expressions** - Dynamic facial animations and emotions driven by LLM responses
 - [ ] **Live2D Support** - Alternative to VRM for 2D animated avatars
-- [ ] **Expanded Default Avatars** - More built-in 3D avatar options to choose from
-- [ ] **Photo Mode** - Full-featured photo mode with character posing, lighting adjustments, and high-quality saves
+- [ ] **Windows and Linux Desktop Apps** - Expand desktop builds beyond the current macOS beta
 
 ## Contributing
 

--- a/src/content/blog/dev-log-2026-5-29.md
+++ b/src/content/blog/dev-log-2026-5-29.md
@@ -1,0 +1,49 @@
+---
+title: Dev Log @2026.5.29
+description: A quick update from CJ on where Utsuwa has been, what changed, and the roadmap for active development.
+date: '2026-05-29'
+image: /blog/blog-thumbnail.png
+tag: DevLog
+---
+
+# Dev Log @2026.5.29
+
+It has been a while.
+
+If I am being honest, Utsuwa began early this year as a small dev project for me. I wanted to experiment with VRM, LLMs, local-first storage, and the shape of an AI companion that felt like something you owned rather than something rented from a closed platform.
+
+A lot has changed in the entire industry since then. LLM development has moved incredibly fast, local models have become more capable, multimodal systems are becoming normal, and many of the other projects I am involved in had taken precedence for a bit.
+
+To my surprise, when I checked back in on Utsuwa, over a thousand of you were visiting in a month, and roughly half of those visitors were actually using it. I have also gotten several messages on social media about the project: cool experiments, bug reports, questions, and ideas for where this could go.
+
+That changed how I think about the project.
+
+Utsuwa is moving beyond just an experiment. It is going to be in active development moving forward, and there is a lot of work to do.
+
+## What just changed
+
+The latest round of work focused on one of the most important pieces of the project: local LLMs.
+
+Local models are essential to what Utsuwa is trying to be. If this is an open-source AI companion that respects ownership and privacy, then connecting to tools like Ollama and LM Studio cannot feel fragile or confusing.
+
+The app now discovers installed local models directly from Ollama and LM Studio instead of asking you to manually type a model name. That should make setup clearer, especially for people who are new to local AI and just want to know which models are available on their machine.
+
+There is also better troubleshooting around Ollama browser access. If you use Utsuwa from a hosted site, your browser still has to be allowed by Ollama through `OLLAMA_ORIGINS`. That is how Ollama works, and the app now tries to explain it more clearly instead of leaving you with a vague failed request.
+
+## The roadmap
+
+Here is the current development roadmap I am focusing on:
+
+- **File, image, and video uploads** - Many LLMs are multimodal now, and Utsuwa should support richer context than plain text. This also opens the door for providers and tools that can work with files, images, video, and web-aware workflows.
+- **OpenAI-compatible models** - A lot of services and local servers expose OpenAI-compatible APIs. Utsuwa should make it easier to point at those endpoints without requiring every compatible provider to be hardcoded.
+- **Multi-provider STT** - Voice input currently supports Groq and the browser Web Speech API. I want to add more speech-to-text options so users have more flexibility across platforms and providers.
+- **Live2D support** - VRM is still core to the project, but Live2D would open the door for 2D animated companions as an alternative style.
+- **Windows and Linux desktop apps** - The desktop app is currently macOS-focused. Windows and Linux builds are important for making the project more accessible.
+
+## Where this is going
+
+The north star has not changed: Utsuwa should be an open, local-first AI companion that you can shape, inspect, and own.
+
+What has changed is that it is no longer just a weekend experiment sitting on a shelf. People are using it, people are asking for it to improve, and that makes the work feel worth continuing in a more serious way.
+
+Thanks to everyone who has tried it, reported bugs, sent messages, or just poked around. More updates soon.


### PR DESCRIPTION
## Summary
- add CJ Dyas dev log for 2026-05-29
- refresh README provider/configuration language for current local model discovery behavior
- replace the planned roadmap with the current active roadmap items

## Validation
- pnpm test
- pnpm lint
- pnpm build
- opened http://localhost:5173/blog/dev-log-2026-5-29 locally and confirmed the page title/render with no console errors

## Notes
- Build still shows existing Svelte warnings and the existing Pagefind no-static-HTML fallback, but exits successfully.