### PR TITLE
Add crypto scam warning to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Utsuwa (器)
 
+> [!WARNING]
+> Utsuwa and The Lab by Ordinary Company have not minted, launched, endorsed, or authorized any cryptocurrency, token, coin, NFT, or blockchain project. We never will. If you see crypto associated with Utsuwa or The Lab, it is a scam. This repository is the only authentic Utsuwa project repository.
+
 <p align="center">
   <img src="static/brand-assets/read-me-banner.png" alt="Utsuwa Banner" />
 </p>


### PR DESCRIPTION
## Summary
- add a prominent warning at the top of the README that Utsuwa and The Lab by Ordinary Company have not and will never mint or endorse crypto, tokens, coins, NFTs, or blockchain projects
- clarify that crypto associated with Utsuwa or The Lab is a scam
- state that this repository is the only authentic Utsuwa project repository

## Validation
- README-only change; reviewed the rendered GitHub Markdown warning syntax locally via diff
