### PR TITLE
Add Star History chart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,3 +288,13 @@ Utsuwa is built on the shoulders of these excellent projects:
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+## Star History
+
+<a href="https://www.star-history.com/?repos=The-Lab-by-Ordinary-Company%2Futsuwa&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=The-Lab-by-Ordinary-Company/utsuwa&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=The-Lab-by-Ordinary-Company/utsuwa&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=The-Lab-by-Ordinary-Company/utsuwa&type=date&legend=top-left" />
+ </picture>
+</a>


### PR DESCRIPTION
## Summary
- add a Star History section at the bottom of the README
- embed the repository star chart with light/dark SVG sources
- link the chart to the Star History page for this repo

## Validation
- README-only change; reviewed the diff and matched Star History's documented GitHub README SVG embed format
