### PR TITLE
Landing page glow-up, themed docs + blog, and subdomain routing

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,5 +1,9 @@
 @import 'tailwindcss';
 
+/* Drive Tailwind's dark: variant from the .dark class the app toggles,
+   not the OS media query (the theme toggle sets .dark on <html>). */
+@custom-variant dark (&:where(.dark, .dark *));
+
 /* bits-ui compatible theme */
 @theme inline {
 	--color-background: var(--bg-primary);

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,0 +1,22 @@
+import type { Reroute } from '@sveltejs/kit';
+
+// Subdomain → internal route prefix. On docs.utsuwa.ai a request for
+// `/overview/introduction` is routed to `/docs/overview/introduction`, and
+// app.utsuwa.ai/settings → /app/settings. This runs on both the server and
+// during client-side navigation, so clean subdomain URLs resolve everywhere.
+// "Prepend only if missing" keeps already-prefixed paths working as a safety net.
+export const reroute: Reroute = ({ url }) => {
+	const host = url.hostname;
+
+	if (host.startsWith('docs.')) {
+		if (!url.pathname.startsWith('/docs')) {
+			return url.pathname === '/' ? '/docs' : `/docs${url.pathname}`;
+		}
+	} else if (host.startsWith('app.')) {
+		if (!url.pathname.startsWith('/app')) {
+			return url.pathname === '/' ? '/app' : `/app${url.pathname}`;
+		}
+	}
+
+	// Main domain / localhost: leave the path untouched.
+};

--- a/src/lib/components/docs/DocsGetStartedCards.svelte
+++ b/src/lib/components/docs/DocsGetStartedCards.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Icon from '$lib/components/ui/Icon.svelte';
 	import { GITHUB_RELEASES } from '$lib/config/site';
+	import { localPath, sectionUrl } from '$lib/config/links';
 </script>
 
 <div class="cards">
@@ -14,12 +15,12 @@
 			No installation required. Runs entirely in your browser — works on desktop and mobile.
 		</p>
 		<div class="card-actions">
-			<a href="https://utsuwa.ai" target="_blank" rel="noopener noreferrer" class="card-btn primary">
+			<a href={sectionUrl('app')} class="card-btn primary">
 				<span>Open App</span>
 				<Icon name="arrow-right" size={14} />
 				<div class="btn-shine"></div>
 			</a>
-			<a href="/docs/guides/web-guide" class="card-link">How to use?</a>
+			<a href={localPath('docs', '/guides/web-guide')} class="card-link">How to use?</a>
 		</div>
 	</div>
 
@@ -38,7 +39,7 @@
 				<Icon name="download" size={14} />
 				<div class="btn-shine"></div>
 			</a>
-			<a href="/docs/guides/desktop-guide" class="card-link">Setup guide</a>
+			<a href={localPath('docs', '/guides/desktop-guide')} class="card-link">Setup guide</a>
 		</div>
 	</div>
 </div>

--- a/src/lib/components/docs/DocsHeader.svelte
+++ b/src/lib/components/docs/DocsHeader.svelte
@@ -4,6 +4,7 @@
 	import { page } from '$app/state';
 	import { cycleTheme, getIconName, getLabel } from '$lib/config/docs-theme-toggle.svelte';
 	import { GITHUB_RELEASES } from '$lib/config/site';
+	import { localPath, sectionUrl, mainUrl, isSection } from '$lib/config/links';
 
 	interface Props {
 		onToggleSidebar?: () => void;
@@ -33,7 +34,7 @@
 				<Icon name={sidebarOpen ? 'xmark' : 'bars'} size={18} />
 			</button>
 		{/if}
-		<a href="/docs" class="logo desktop-logo">
+		<a href={localPath('docs')} class="logo desktop-logo">
 			<img src="/brand-assets/logo.svg" alt="Utsuwa" class="logo-img" />
 		</a>
 	</div>
@@ -42,13 +43,13 @@
 			<DocsSearch bind:this={searchComponent} id="header-search" />
 		</div>
 	{/if}
-	<a href="/docs" class="logo mobile-logo">
+	<a href={localPath('docs')} class="logo mobile-logo">
 		<img src="/brand-assets/logo.svg" alt="Utsuwa" class="logo-img" />
 	</a>
 	<div class="header-right">
 		<nav class="header-nav">
-			<a href="/docs" class="nav-link" class:active={currentPath.startsWith('/docs')}>Docs</a>
-			<a href="/blog" class="nav-link" class:active={currentPath.startsWith('/blog')}>Blog</a>
+			<a href={localPath('docs')} class="nav-link" class:active={isSection('docs')}>Docs</a>
+			<a href={mainUrl('/blog')} class="nav-link" class:active={currentPath.startsWith('/blog')}>Blog</a>
 		</nav>
 		{#if !hideThemeToggle}
 			<button type="button" class="header-btn" onclick={cycleTheme} aria-label={label} title={label}>
@@ -59,7 +60,7 @@
 			<Icon name="download" size={14} />
 			Download
 		</a>
-		<a href="/app" class="try-live-btn">Try Live</a>
+		<a href={sectionUrl('app')} class="try-live-btn">Try Live</a>
 	</div>
 </header>
 
@@ -106,8 +107,7 @@
 	.logo-img {
 		height: 1.5rem;
 		width: auto;
-		filter: var(--docs-logo-filter, none);
-		drop-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+		filter: var(--docs-logo-filter, none) drop-shadow(0 1px 2px rgba(0, 0, 0, 0.1));
 	}
 
 	.header-nav {

--- a/src/lib/components/docs/DocsPrevNext.svelte
+++ b/src/lib/components/docs/DocsPrevNext.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { getPrevNext } from '$lib/utils/docs-nav';
 	import Icon from '$lib/components/ui/Icon.svelte';
+	import { localPath } from '$lib/config/links';
 
 	interface Props {
 		slug: string;
@@ -13,7 +14,7 @@
 
 <nav class="prev-next" aria-label="Page navigation">
 	{#if prev}
-		<a href="/docs/{prev.slug}" class="nav-link prev">
+		<a href={localPath('docs', `/${prev.slug}`)} class="nav-link prev">
 			<Icon name="chevron-left" size={16} />
 			<div class="nav-text">
 				<span class="label">Previous</span>
@@ -25,7 +26,7 @@
 	{/if}
 
 	{#if next}
-		<a href="/docs/{next.slug}" class="nav-link next">
+		<a href={localPath('docs', `/${next.slug}`)} class="nav-link next">
 			<div class="nav-text">
 				<span class="label">Next</span>
 				<span class="title">{next.title}</span>

--- a/src/lib/components/docs/DocsSearch.svelte
+++ b/src/lib/components/docs/DocsSearch.svelte
@@ -2,6 +2,7 @@
 	import { goto } from '$app/navigation';
 	import { browser } from '$app/environment';
 	import Icon from '$lib/components/ui/Icon.svelte';
+	import { localPath } from '$lib/config/links';
 
 	interface Props {
 		id?: string;
@@ -99,7 +100,10 @@
 		close();
 		// Strip .html extension - Pagefind indexes HTML files but SvelteKit uses clean URLs
 		const cleanUrl = url.replace(/\.html$/, '');
-		goto(cleanUrl);
+		// Pagefind indexes the built /docs/... paths; map them to the host-aware
+		// path so search results land on clean subdomain URLs.
+		const docsPath = cleanUrl.replace(/^\/docs(?=\/|$)/, '');
+		goto(localPath('docs', docsPath));
 	}
 
 	function close() {

--- a/src/lib/components/docs/DocsSidebarSection.svelte
+++ b/src/lib/components/docs/DocsSidebarSection.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Icon from '$lib/components/ui/Icon.svelte';
 	import { page } from '$app/state';
+	import { localPath } from '$lib/config/links';
 	import type { DocsNavSection } from '$lib/config/docs-nav';
 
 	interface Props {
@@ -17,7 +18,7 @@
 	</div>
 	<ul class="section-items">
 		{#each section.items as item}
-			{@const href = `/docs/${item.slug}`}
+			{@const href = localPath('docs', `/${item.slug}`)}
 			{@const isActive = page.url.pathname === href}
 			<li>
 				<a {href} class="section-link" class:active={isActive} aria-current={isActive ? 'page' : undefined}>

--- a/src/lib/components/layout/Header.svelte
+++ b/src/lib/components/layout/Header.svelte
@@ -2,13 +2,14 @@
 	import { goto } from '$app/navigation';
 	import { vrmStore } from '$lib/stores/vrm.svelte';
 	import { Dropdown, DropdownItem, DropdownSeparator, Icon } from '$lib/components/ui';
+	import { localPath } from '$lib/config/links';
 
 	const activeModel = $derived(vrmStore.getActiveModel());
 </script>
 
 <header class="header">
 	<div class="header-left">
-		<a href="/app" class="logo-link">
+		<a href={localPath('app')} class="logo-link">
 			<div class="logo">
 				<svg width="32" height="32" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
 					<circle cx="50" cy="50" r="45" stroke="currentColor" stroke-width="6" fill="none" opacity="0.3"/>
@@ -47,15 +48,15 @@
 				<DropdownSeparator />
 
 				<!-- Menu Items -->
-				<DropdownItem onclick={() => goto('/app/settings/vrm')}>
+				<DropdownItem onclick={() => goto(localPath('app', '/settings/vrm'))}>
 					<Icon name="user" size={16} />
 					Change Avatar
 				</DropdownItem>
-				<DropdownItem onclick={() => goto('/app/settings/relationship')}>
+				<DropdownItem onclick={() => goto(localPath('app', '/settings/relationship'))}>
 					<Icon name="heart" size={16} />
 					Relationship
 				</DropdownItem>
-				<DropdownItem onclick={() => goto('/app/settings')}>
+				<DropdownItem onclick={() => goto(localPath('app', '/settings'))}>
 					<Icon name="settings" size={16} />
 					Settings
 				</DropdownItem>

--- a/src/lib/components/ui/CompanionStatus.svelte
+++ b/src/lib/components/ui/CompanionStatus.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { characterStore } from '$lib/stores/character.svelte';
 	import { Icon } from '$lib/components/ui';
+	import { localPath } from '$lib/config/links';
 
 	interface Props {
 		overlay?: boolean;
@@ -153,7 +154,7 @@
 								<span>{charState.currentStreak}</span>
 							</div>
 						{/if}
-						<a href="/app/settings/persona" class="quick-stat profile-link">
+						<a href={localPath('app', '/settings/persona')} class="quick-stat profile-link">
 							<span>Profile</span>
 							<Icon name="arrow-right" size={11} />
 						</a>

--- a/src/lib/components/ui/InfoModal.svelte
+++ b/src/lib/components/ui/InfoModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Icon } from '$lib/components/ui';
 	import { onMount } from 'svelte';
+	import { sectionUrl } from '$lib/config/links';
 
 	interface Props {
 		onClose: () => void;
@@ -79,7 +80,7 @@
 				<span class="tile-label">GitHub</span>
 				<span class="tile-shine"></span>
 			</a>
-			<a href="/docs" class="link-tile" style="--delay: 1; --tile-color: #01B2FF; --tile-glow: rgba(1, 178, 255, 0.3)">
+			<a href={sectionUrl('docs')} class="link-tile" style="--delay: 1; --tile-color: #01B2FF; --tile-glow: rgba(1, 178, 255, 0.3)">
 				<div class="tile-icon-wrapper">
 					<span class="tile-icon">
 						<Icon name="file-text" size={20} />

--- a/src/lib/components/ui/TopRightButtons.svelte
+++ b/src/lib/components/ui/TopRightButtons.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { Icon } from '$lib/components/ui';
+	import { localPath } from '$lib/config/links';
 	import { isTauri } from '$lib/services/platform';
 	import { onMount } from 'svelte';
 
@@ -39,7 +40,7 @@
 	<button class="icon-btn" onclick={onInfoClick} aria-label="App info">
 		<Icon name="info" size={20} />
 	</button>
-	<button class="icon-btn" onclick={() => goto('/app/settings')} aria-label="Settings">
+	<button class="icon-btn" onclick={() => goto(localPath('app', '/settings'))} aria-label="Settings">
 		<Icon name="settings" size={20} />
 	</button>
 </div>

--- a/src/lib/config/links.ts
+++ b/src/lib/config/links.ts
@@ -1,0 +1,61 @@
+import { page } from '$app/state';
+
+/**
+ * Host-aware link builder for the subdomain split (docs.utsuwa.ai, app.utsuwa.ai).
+ *
+ * - On the real utsuwa.ai (apex or any subdomain): links resolve to the right
+ *   subdomain via absolute URLs. Same-origin links stay client-side (SPA) nav,
+ *   cross-subdomain links do a normal full navigation.
+ * - In local dev (localhost) and on *.vercel.app preview deploys: everything
+ *   stays path-based (/docs, /app), so there's nothing to set up to test.
+ *
+ * The reroute hook (src/hooks.ts) maps the clean subdomain paths back to the
+ * real /docs and /app routes.
+ */
+
+type Section = 'docs' | 'app';
+const APEX = 'utsuwa.ai';
+
+function hostname(): string {
+	return page.url?.hostname ?? '';
+}
+
+// Only the real production domain uses the subdomain split. localhost and
+// preview deploys (e.g. *.vercel.app) fall back to path-based routing.
+function usesSubdomains(): boolean {
+	return hostname().endsWith(APEX);
+}
+
+function norm(path: string): string {
+	if (!path) return '';
+	return path.startsWith('/') ? path : `/${path}`;
+}
+
+/** Link to a page inside a section (docs or app). */
+export function sectionUrl(section: Section, path = ''): string {
+	const clean = norm(path);
+	return usesSubdomains() ? `https://${section}.${APEX}${clean}` : `/${section}${clean}`;
+}
+
+/** Link to a page on the main marketing site (the apex domain). */
+export function mainUrl(path = ''): string {
+	const clean = norm(path);
+	return usesSubdomains() ? `https://${APEX}${clean}` : clean || '/';
+}
+
+/**
+ * The *relative* browser path for a section page on the current host — clean
+ * ("/overview") when already on that section's subdomain, prefixed
+ * ("/docs/overview") otherwise. Use for within-section links and for comparing
+ * against `page.url.pathname` (active states), since those must match.
+ */
+export function localPath(section: Section, path = ''): string {
+	const clean = norm(path);
+	const onThisSubdomain = usesSubdomains() && hostname().startsWith(`${section}.`);
+	return onThisSubdomain ? clean || '/' : `/${section}${clean}`;
+}
+
+/** Whether the current page belongs to a section (subdomain or path-prefixed). */
+export function isSection(section: Section): boolean {
+	return hostname().startsWith(`${section}.`) || (page.url?.pathname ?? '').startsWith(`/${section}`);
+}

--- a/src/lib/config/site.ts
+++ b/src/lib/config/site.ts
@@ -1,3 +1,5 @@
 export const SITE_URL = 'https://utsuwa.ai';
+export const DOCS_URL = 'https://docs.utsuwa.ai';
+export const APP_URL = 'https://app.utsuwa.ai';
 export const GITHUB_REPO = 'https://github.com/The-Lab-by-Ordinary-Company/utsuwa';
 export const GITHUB_RELEASES = `${GITHUB_REPO}/releases`;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,8 +3,97 @@
 	import { formatDate } from '$lib/utils/format-date';
 	import { SITE_URL, GITHUB_REPO, GITHUB_RELEASES } from '$lib/config/site';
 	import Icon from '$lib/components/ui/Icon.svelte';
+	import ProviderIcons from '$lib/components/icons/ProviderIcons.svelte';
+	import { cycleTheme, getIconName, getLabel } from '$lib/config/docs-theme-toggle.svelte';
+	import { sectionUrl } from '$lib/config/links';
 
 	let { data }: { data: PageData } = $props();
+
+	// Theme toggle (shares the app/docs colorMode + .dark mechanism).
+	const themeIcon = $derived(getIconName());
+	const themeLabel = $derived(getLabel());
+
+	// Scroll-reveal action. Fires once when an element enters the viewport,
+	// staggered by an optional delay. Bails out to "always visible" when the
+	// user prefers reduced motion or IntersectionObserver isn't around.
+	function reveal(node: HTMLElement, delay = 0) {
+		if (typeof IntersectionObserver === 'undefined') {
+			node.classList.add('revealed');
+			return;
+		}
+		if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+			node.classList.add('revealed');
+			return;
+		}
+		node.style.setProperty('--reveal-delay', `${delay}ms`);
+		const obs = new IntersectionObserver(
+			(entries) => {
+				for (const entry of entries) {
+					if (entry.isIntersecting) {
+						node.classList.add('revealed');
+						obs.unobserve(node);
+					}
+				}
+			},
+			{ threshold: 0.18, rootMargin: '0px 0px -8% 0px' }
+		);
+		obs.observe(node);
+		return { destroy: () => obs.disconnect() };
+	}
+
+	// Every provider we actually support today — keep this honest.
+	// `icon` maps to the keys in ProviderIcons' PROVIDER_ICONS map.
+	const providers = [
+		{ name: 'OpenAI', icon: 'openai' },
+		{ name: 'Anthropic', icon: 'anthropic' },
+		{ name: 'Google', icon: 'google' },
+		{ name: 'DeepSeek', icon: 'deepseek' },
+		{ name: 'xAI', icon: 'xai' },
+		{ name: 'Ollama', icon: 'ollama' },
+		{ name: 'LM Studio', icon: 'lmstudio' },
+		{ name: 'Groq Whisper', icon: 'groq' },
+		{ name: 'ElevenLabs', icon: 'elevenlabs' }
+	];
+
+	const stats = [
+		{ value: '100%', label: 'Local & private' },
+		{ value: '0', label: 'Accounts required' },
+		{ value: '9+', label: 'AI providers' },
+		{ value: 'MIT', label: 'Open source' }
+	];
+
+	const bento = [
+		{
+			icon: 'monitor',
+			title: 'Desktop overlay',
+			body: 'Pin your companion on top of everything with a transparent background, draggable anywhere, summoned by a global hotkey.'
+		},
+		{
+			icon: 'mic',
+			title: 'Talk, out loud',
+			body: 'Speak with Groq Whisper or the Web Speech API and hear replies back through ElevenLabs or OpenAI voices.'
+		},
+		{
+			icon: 'lock',
+			title: 'Stays on your machine',
+			body: 'Everything lives in IndexedDB on your device. No account, no cloud sync, no telemetry. Export and import whenever you want.'
+		},
+		{
+			icon: 'sparkles',
+			title: 'Alive, not idle',
+			body: 'Idle motion, automatic blinking, mood-driven expressions and lip-sync that actually tracks what she is saying.'
+		},
+		{
+			icon: 'code',
+			title: 'Yours to fork',
+			body: 'MIT licensed and built on SvelteKit, Three.js and Tauri. Self-host it, rip it apart, send a PR.'
+		},
+		{
+			icon: 'layers',
+			title: 'Desktop and web',
+			body: 'A native macOS app for the full experience, plus a web build that runs in any modern browser. Same companion, same save file.'
+		}
+	];
 </script>
 
 <svelte:head>
@@ -52,10 +141,23 @@
 	})}</script>`}
 </svelte:head>
 
-<div class="bg-white text-[#0a0a0a] overflow-x-hidden">
+<div class="bg-white dark:bg-[#0a0a0a] text-[#0a0a0a] dark:text-[#fafafa] overflow-x-hidden">
 <main>
 	<!-- Hero -->
-	<section class="relative min-h-screen bg-gradient-to-b from-[#4dd0ff] via-[#01B2FF] to-white">
+	<section class="hero relative min-h-screen bg-gradient-to-b from-[#4dd0ff] via-[#01B2FF] to-white">
+		<!-- Animated aurora wash -->
+		<div class="hero-aurora pointer-events-none absolute inset-0"></div>
+
+		<!-- Frutiger Aero glass bubbles -->
+		<div class="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
+			<span class="aero-bubble" style="--size:120px; --x:8%;  --y:62%; --dur:13s; --delay:-2s;"></span>
+			<span class="aero-bubble" style="--size:64px;  --x:18%; --y:30%; --dur:17s; --delay:-6s;"></span>
+			<span class="aero-bubble" style="--size:200px; --x:78%; --y:24%; --dur:21s; --delay:-1s;"></span>
+			<span class="aero-bubble" style="--size:90px;  --x:88%; --y:60%; --dur:15s; --delay:-9s;"></span>
+			<span class="aero-bubble" style="--size:44px;  --x:62%; --y:14%; --dur:11s; --delay:-4s;"></span>
+			<span class="aero-bubble" style="--size:150px; --x:40%; --y:78%; --dur:23s; --delay:-12s;"></span>
+		</div>
+
 		<!-- Nav -->
 		<nav class="relative z-10 max-w-7xl mx-auto flex items-center justify-between px-6 py-5">
 			<a href="/" class="flex items-center">
@@ -64,7 +166,7 @@
 
 			<div class="hidden md:flex items-center gap-6 text-sm text-white/80">
 				<a href="#features" class="hover:text-white transition-colors">Features</a>
-				<a href="/docs" class="hover:text-white transition-colors">Docs</a>
+				<a href={sectionUrl('docs')} class="hover:text-white transition-colors">Docs</a>
 				<a href="/blog" class="hover:text-white transition-colors">Blog</a>
 				<a
 					href={GITHUB_REPO}
@@ -76,32 +178,52 @@
 				</a>
 			</div>
 
-			<a
-				href="/app"
-				class="skeu-btn-sm text-xs font-semibold px-4 py-2 rounded-full transition-all"
-			>
-				Try Live
-			</a>
+			<div class="flex items-center gap-2">
+				<button
+					type="button"
+					onclick={cycleTheme}
+					class="nav-theme-btn"
+					aria-label={`Theme: ${themeLabel}`}
+					title={themeLabel}
+				>
+					<Icon name={themeIcon} size={16} />
+				</button>
+				<a
+					href={sectionUrl('app')}
+					class="skeu-btn-sm text-xs font-semibold px-4 py-2 rounded-full transition-all"
+				>
+					Try Live
+				</a>
+			</div>
 		</nav>
 
 		<!-- Hero content -->
-		<div class="relative z-10 flex flex-col items-center justify-center mt-16 px-6">
+		<div class="relative z-10 flex flex-col items-center justify-center mt-12 md:mt-16 px-6">
 			<h1 class="sr-only">Utsuwa — Open-Source AI Companion with 3D VRM Avatars</h1>
+
+			<!-- Eyebrow pill -->
+			<div use:reveal class="reveal glass-pill mb-7" >
+				<span class="glass-pill-dot"></span>
+				Open source &middot; MIT &middot; Self-hosted
+			</div>
+
 			<!-- Logo -->
 			<img
+				use:reveal={80}
 				src="/brand-assets/logo.svg"
 				alt="Utsuwa — AI companion app"
-				class="hero-logo mb-6"
+				class="reveal hero-logo mb-6"
 			/>
 
 			<!-- Subtitle -->
-			<p class="text-lg md:text-xl text-white/80 text-center max-w-2xl mb-8">
-				Open-source VRM avatar viewer with AI chat, voice, and semantic memory.
+			<p use:reveal={160} class="reveal text-lg md:text-xl text-white/85 text-center text-pretty max-w-2xl mb-8">
+				A vessel for AI to live in. Load a 3D avatar, give it a brain, and talk to a companion that
+				speaks, listens, and remembers — entirely on your own machine.
 			</p>
 
 			<!-- CTA buttons -->
-			<div class="flex flex-wrap items-center justify-center gap-3 mb-12">
-				<a href="/app" class="skeu-btn-glass text-sm font-bold px-6 py-3 rounded-full transition-all">
+			<div use:reveal={240} class="reveal flex flex-wrap items-center justify-center gap-3 mb-12">
+				<a href={sectionUrl('app')} class="skeu-btn-glass text-sm font-bold px-6 py-3 rounded-full transition-all">
 					Try Live
 				</a>
 				<a
@@ -113,7 +235,7 @@
 					Download
 				</a>
 				<a
-					href="/docs"
+					href={sectionUrl('docs')}
 					class="skeu-btn-glass-outline text-sm font-medium px-6 py-3 rounded-full transition-all"
 				>
 					Docs
@@ -121,8 +243,8 @@
 			</div>
 
 			<!-- Screenshot card -->
-			<div class="max-w-[1067px] w-full mx-auto px-4">
-				<div class="rounded-xl overflow-hidden shadow-2xl border border-white/10">
+			<div use:reveal={320} class="reveal screenshot-stage max-w-[1067px] w-full mx-auto px-4">
+				<div class="screenshot-frame rounded-xl overflow-hidden">
 					<img
 						src="/landing-page/utsuwa-thumbnail.png"
 						alt="Utsuwa desktop app showing a 3D VRM avatar companion with chat interface"
@@ -131,274 +253,179 @@
 				</div>
 			</div>
 
-			<!-- Tagline below screenshot -->
-			<p
-				class="max-w-2xl mt-16 md:mt-24 text-xl md:text-2xl font-semibold text-[#1a1a1a] tracking-tight text-center"
-			>
-				A vessel for AI to inhabit. Chat, listen, remember — your companion, your way.
-			</p>
-		</div>
-
-		<!-- Decorative glass floaters -->
-		<div
-			class="hidden md:block absolute top-[40%] left-[-5%] w-[400px] h-[300px] glass-panel rounded-xl opacity-60 -rotate-6 scale-75 md:scale-90 pointer-events-none"
-		>
-			<div class="flex items-center gap-1.5 px-3 py-2">
-				<div class="w-2.5 h-2.5 rounded-full bg-white/40"></div>
-				<div class="w-2.5 h-2.5 rounded-full bg-white/30"></div>
-				<div class="w-2.5 h-2.5 rounded-full bg-white/20"></div>
+			<!-- Stat row -->
+			<div use:reveal={120} class="reveal grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4 mt-12 mb-12 md:mb-16 w-full max-w-3xl">
+				{#each stats as stat}
+					<div class="stat-tile">
+						<div class="stat-value">{stat.value}</div>
+						<div class="stat-label">{stat.label}</div>
+					</div>
+				{/each}
 			</div>
-			<div
-				class="mx-3 mt-2 h-full rounded-lg bg-gradient-to-b from-white/10 to-transparent"
-			></div>
-		</div>
-
-		<div
-			class="hidden md:block absolute top-[35%] right-[-5%] w-[450px] h-[320px] glass-panel rounded-xl opacity-70 rotate-3 scale-75 md:scale-90 pointer-events-none"
-		>
-			<div class="flex items-center gap-1.5 px-3 py-2">
-				<div class="w-2.5 h-2.5 rounded-full bg-white/40"></div>
-				<div class="w-2.5 h-2.5 rounded-full bg-white/30"></div>
-				<div class="w-2.5 h-2.5 rounded-full bg-white/20"></div>
-			</div>
-			<div
-				class="mx-3 mt-2 h-full rounded-lg bg-gradient-to-b from-white/10 to-transparent"
-			></div>
 		</div>
 
 		<!-- Bottom gradient fade -->
 		<div
-			class="absolute bottom-0 left-0 w-full h-64 bg-gradient-to-t from-white via-white/80 to-transparent pointer-events-none"
+			class="absolute bottom-0 left-0 w-full h-64 bg-gradient-to-t from-white via-white/80 to-transparent dark:from-[#0a0a0a] dark:via-[#0a0a0a]/80 pointer-events-none"
 		></div>
 	</section>
 
-	<!-- Feature A: Meet your AI companion -->
-	<section id="features" class="bg-white border-t border-black/5">
-		<div class="max-w-7xl mx-auto px-6 py-24 md:py-32">
-			<div class="text-center mb-16 md:mb-24">
-				<h2
-					class="text-4xl md:text-5xl lg:text-6xl font-semibold text-[#1a1a1a] tracking-tight"
-					style="font-family: 'Exo 2', sans-serif;"
-				>
-					Meet your AI companion
-				</h2>
-			</div>
-
-			<div class="grid lg:grid-cols-2 gap-12 items-center">
-				<div
-					class="skeu-card-light rounded-xl aspect-[4/3] flex items-center justify-center overflow-hidden p-4"
-				>
-					<img src="/landing-page/speaking-shot-1.png" alt="3D VRM avatar with speech bubble and lip-sync animation" class="w-full h-full object-contain rounded-lg" />
-				</div>
-
-				<div class="flex flex-col items-start max-w-lg mx-auto lg:mx-0">
-					<div
-						class="skeu-badge inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-medium mb-6"
-					>
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							width="12"
-							height="12"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="2"
-							stroke-linecap="round"
-							stroke-linejoin="round"
-						>
-							<path
-								d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z"
-							/>
-						</svg>
-						3D Avatar
-					</div>
-					<h3 class="text-2xl md:text-3xl font-medium text-[#1a1a1a] mb-4 tracking-tight">
-						Full 3D avatars, anywhere.
-					</h3>
-					<p class="text-lg text-black/50 leading-relaxed">
-						Load any VRM avatar model and watch it come to life with idle animations, automatic
-						blinking, and speech-driven lip-sync. Chat responses appear as 3D speech bubbles that
-						track your companion's head position.
-					</p>
-				</div>
-			</div>
-		</div>
-	</section>
-
-	<!-- Feature B: She remembers -->
-	<section class="bg-[#f5f7fa] border-t border-black/5">
-		<div class="max-w-7xl mx-auto px-6 py-24 md:py-32">
-			<div class="text-center mb-16 md:mb-24">
-				<h2
-					class="text-4xl md:text-5xl lg:text-6xl font-semibold text-[#1a1a1a] tracking-tight"
-					style="font-family: 'Exo 2', sans-serif;"
-				>
-					She remembers
-				</h2>
-			</div>
-
-			<div class="grid lg:grid-cols-2 gap-12 items-center">
-				<div class="flex flex-col items-start max-w-lg mx-auto lg:mx-0 order-2 lg:order-1">
-					<div
-						class="skeu-badge inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-medium mb-6"
-					>
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							width="12"
-							height="12"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="2"
-							stroke-linecap="round"
-							stroke-linejoin="round"
-						>
-							<path
-								d="m16.24 7.76-1.804 5.411a2 2 0 0 1-1.265 1.265L7.76 16.24l1.804-5.411a2 2 0 0 1 1.265-1.265z"
-							/>
-							<circle cx="12" cy="12" r="10" />
-						</svg>
-						Semantic Memory
-					</div>
-					<h3 class="text-2xl md:text-3xl font-medium text-[#1a1a1a] mb-4 tracking-tight">
-						Memories that mean something.
-					</h3>
-					<p class="text-lg text-black/50 leading-relaxed">
-						Your companion builds a web of memories using local AI embeddings. She finds past
-						conversations by meaning, not keywords. Track affection, trust, and mood across 8
-						relationship stages — from Stranger to Soulmate.
-					</p>
-				</div>
-
-				<div
-					class="skeu-card-light rounded-xl aspect-[4/3] flex items-center justify-center overflow-hidden p-4 order-1 lg:order-2"
-				>
-					<img src="/landing-page/memory-graph.png" alt="Semantic memory graph showing AI companion relationship and conversation history" class="w-full h-full object-contain rounded-lg" />
-				</div>
-			</div>
-		</div>
-	</section>
-
-	<!-- Feature C: You're in control -->
-	<section class="bg-white border-t border-black/5">
-		<div class="max-w-7xl mx-auto px-6 py-24 md:py-32">
-			<div class="text-center mb-16 md:mb-24">
-				<h2
-					class="text-4xl md:text-5xl lg:text-6xl font-semibold text-[#1a1a1a] tracking-tight"
-					style="font-family: 'Exo 2', sans-serif;"
-				>
-					You're in control
-				</h2>
-			</div>
-
-			<div class="grid lg:grid-cols-2 gap-12 items-center">
-				<div
-					class="skeu-card-light rounded-xl aspect-[4/3] flex items-center justify-center overflow-hidden p-4"
-				>
-					<img src="/landing-page/ai-services.png" alt="Settings panel showing LLM provider options including OpenAI, Anthropic, and Ollama" class="w-full h-full object-contain rounded-lg" />
-				</div>
-
-				<div class="flex flex-col items-start max-w-lg mx-auto lg:mx-0">
-					<div
-						class="skeu-badge inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-medium mb-6"
-					>
-						<Icon name="settings" size={12} />
-						Bring Your Own Keys
-					</div>
-					<h3 class="text-2xl md:text-3xl font-medium text-[#1a1a1a] mb-4 tracking-tight">
-						Pick your providers. Use your keys.
-					</h3>
-					<p class="text-lg text-black/50 leading-relaxed">
-						Choose from OpenAI, Anthropic, Google, DeepSeek, xAI, or run locally with Ollama and LM
-						Studio. Add voice input via Groq Whisper or Web Speech API, and pick your TTS with
-						ElevenLabs or OpenAI — all with your own API keys.
-					</p>
-				</div>
-			</div>
-		</div>
-	</section>
-
-	<!-- More features grid -->
-	<section class="bg-[#f5f7fa] border-t border-black/5 py-24 md:py-32">
-		<div class="max-w-7xl mx-auto px-6">
+	<!-- Provider strip -->
+	<section class="bg-white dark:bg-[#0a0a0a] border-t border-black/5 dark:border-white/5">
+		<div class="max-w-5xl mx-auto px-6 py-20 md:py-28 text-center">
+			<p use:reveal class="reveal eyebrow justify-center mb-5">Bring your own brain</p>
 			<h2
-				class="text-3xl md:text-4xl font-semibold text-[#1a1a1a] text-center mb-16 tracking-tight"
+				use:reveal={60}
+				class="reveal text-2xl md:text-3xl font-semibold text-[#1a1a1a] dark:text-[#fafafa] tracking-tight text-balance mb-10"
 				style="font-family: 'Exo 2', sans-serif;"
 			>
-				More features
+				Plug in any model. Use your own keys.
 			</h2>
+			<div use:reveal={120} class="reveal flex flex-wrap items-center justify-center gap-2.5 md:gap-3">
+				{#each providers as provider}
+					<span class="provider-chip">
+						<ProviderIcons provider={provider.icon} size={18} />
+						{provider.name}
+					</span>
+				{/each}
+			</div>
+		</div>
+	</section>
 
-			<div class="grid md:grid-cols-3 gap-6 lg:gap-8">
-				<!-- Card 1: Desktop Overlay -->
-				<div class="flex flex-col group cursor-default">
-					<div
-						class="skeu-card-light rounded-2xl aspect-[16/10] mb-6 flex items-center justify-center relative overflow-hidden group-hover:border-[#01B2FF]/30 transition-all duration-500"
-					>
-						<Icon name="monitor" size={48} class="text-black/15 group-hover:text-[#01B2FF]/50 transition-colors duration-500" />
+	<!-- Feature A: Presence -->
+	<section id="features" class="bg-[#f5f7fa] dark:bg-[#101013] border-t border-black/5 dark:border-white/5">
+		<div class="max-w-7xl mx-auto px-6 py-24 md:py-32">
+			<div class="grid lg:grid-cols-2 gap-12 items-center">
+				<div
+					use:reveal
+					class="reveal skeu-card-light rounded-xl aspect-[4/3] flex items-center justify-center overflow-hidden p-4"
+				>
+					<img src="/landing-page/speaking-shot-1.png" alt="3D VRM avatar with speech bubble and lip-sync animation" class="img-outline w-full h-full object-contain rounded-lg" />
+				</div>
+
+				<div use:reveal={120} class="reveal flex flex-col items-start max-w-lg mx-auto lg:mx-0">
+					<p class="eyebrow mb-5"><span class="eyebrow-num">01</span> Presence</p>
+					<h2 class="text-3xl md:text-4xl lg:text-5xl font-semibold text-[#1a1a1a] dark:text-[#fafafa] mb-4 tracking-tight text-balance" style="font-family: 'Exo 2', sans-serif;">
+						A real 3D body, not a chat box.
+					</h2>
+					<p class="text-lg text-black/55 dark:text-white/55 leading-relaxed text-pretty mb-6">
+						Drop in any VRM model and watch it come to life. Replies appear as 3D speech bubbles
+						that follow your companion's head as it moves, breathes, and looks around.
+					</p>
+					<div class="flex flex-wrap gap-2">
+						<span class="feature-chip">Idle animation</span>
+						<span class="feature-chip">Auto-blink</span>
+						<span class="feature-chip">Speech lip-sync</span>
+						<span class="feature-chip">Head-tracked bubbles</span>
 					</div>
-					<div class="px-2">
-						<h3
-							class="text-base font-semibold text-[#1a1a1a] mb-2 text-center md:text-left tracking-tight"
-						>
-							Desktop overlay
-						</h3>
-						<p class="text-sm text-black/50 text-center md:text-left leading-relaxed">
-							Your companion floats on your desktop with a transparent background. Always-on-top,
-							draggable, with global hotkeys.
-						</p>
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<!-- Feature B: Memory -->
+	<section class="bg-white dark:bg-[#0a0a0a] border-t border-black/5 dark:border-white/5">
+		<div class="max-w-7xl mx-auto px-6 py-24 md:py-32">
+			<div class="grid lg:grid-cols-2 gap-12 items-center">
+				<div use:reveal class="reveal flex flex-col items-start max-w-lg mx-auto lg:mx-0 order-2 lg:order-1">
+					<p class="eyebrow mb-5"><span class="eyebrow-num">02</span> Memory</p>
+					<h2 class="text-3xl md:text-4xl lg:text-5xl font-semibold text-[#1a1a1a] dark:text-[#fafafa] mb-4 tracking-tight text-balance" style="font-family: 'Exo 2', sans-serif;">
+						She actually remembers.
+					</h2>
+					<p class="text-lg text-black/55 dark:text-white/55 leading-relaxed text-pretty mb-6">
+						Local AI embeddings weave your conversations into a web of memories she can recall by
+						meaning, not keywords. Affection, trust, and mood shift over time across eight
+						relationship stages — from Stranger to Soulmate.
+					</p>
+					<div class="flex flex-wrap gap-2">
+						<span class="feature-chip">Semantic recall</span>
+						<span class="feature-chip">On-device embeddings</span>
+						<span class="feature-chip">8 relationship stages</span>
+						<span class="feature-chip">Mood &amp; trust</span>
 					</div>
 				</div>
 
-				<!-- Card 2: Local-First -->
-				<div class="flex flex-col group cursor-default">
-					<div
-						class="skeu-card-light rounded-2xl aspect-[16/10] mb-6 flex items-center justify-center relative overflow-hidden group-hover:border-[#01B2FF]/30 transition-all duration-500"
-					>
-						<Icon name="database" size={48} class="text-black/15 group-hover:text-[#01B2FF]/50 transition-colors duration-500" />
-					</div>
-					<div class="px-2">
-						<h3
-							class="text-base font-semibold text-[#1a1a1a] mb-2 text-center md:text-left tracking-tight"
-						>
-							Local-first storage
-						</h3>
-						<p class="text-sm text-black/50 text-center md:text-left leading-relaxed">
-							All data stays on your device in IndexedDB. No account required. Export and import
-							save files anytime.
-						</p>
-					</div>
+				<div
+					use:reveal={120}
+					class="reveal skeu-card-light rounded-xl aspect-[4/3] flex items-center justify-center overflow-hidden p-4 order-1 lg:order-2"
+				>
+					<img src="/landing-page/memory-graph.png" alt="Semantic memory graph showing AI companion relationship and conversation history" class="img-outline w-full h-full object-contain rounded-lg" />
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<!-- Feature C: Control -->
+	<section class="bg-[#f5f7fa] dark:bg-[#101013] border-t border-black/5 dark:border-white/5">
+		<div class="max-w-7xl mx-auto px-6 py-24 md:py-32">
+			<div class="grid lg:grid-cols-2 gap-12 items-center">
+				<div
+					use:reveal
+					class="reveal skeu-card-light rounded-xl aspect-[4/3] flex items-center justify-center overflow-hidden p-4"
+				>
+					<img src="/landing-page/ai-services.png" alt="Settings panel showing LLM provider options including OpenAI, Anthropic, and Ollama" class="img-outline w-full h-full object-contain rounded-lg" />
 				</div>
 
-				<!-- Card 3: Open Source -->
-				<div class="flex flex-col group cursor-default">
-					<div
-						class="skeu-card-light rounded-2xl aspect-[16/10] mb-6 flex items-center justify-center relative overflow-hidden group-hover:border-[#01B2FF]/30 transition-all duration-500"
-					>
-						<Icon name="code" size={48} class="text-black/15 group-hover:text-[#01B2FF]/50 transition-colors duration-500" />
-					</div>
-					<div class="px-2">
-						<h3
-							class="text-base font-semibold text-[#1a1a1a] mb-2 text-center md:text-left tracking-tight"
-						>
-							Open source
-						</h3>
-						<p class="text-sm text-black/50 text-center md:text-left leading-relaxed">
-							MIT licensed. Self-host, modify, contribute. Built with SvelteKit, Three.js, and
-							Tauri.
-						</p>
+				<div use:reveal={120} class="reveal flex flex-col items-start max-w-lg mx-auto lg:mx-0">
+					<p class="eyebrow mb-5"><span class="eyebrow-num">03</span> Control</p>
+					<h2 class="text-3xl md:text-4xl lg:text-5xl font-semibold text-[#1a1a1a] dark:text-[#fafafa] mb-4 tracking-tight text-balance" style="font-family: 'Exo 2', sans-serif;">
+						You own every part of it.
+					</h2>
+					<p class="text-lg text-black/55 dark:text-white/55 leading-relaxed text-pretty mb-6">
+						Run a frontier model or keep it fully offline with Ollama and LM Studio. Mix and match
+						your chat, voice input, and text-to-speech providers — all on your own API keys, with
+						nothing routed through us.
+					</p>
+					<div class="flex flex-wrap gap-2">
+						<span class="feature-chip">Frontier or local</span>
+						<span class="feature-chip">Your API keys</span>
+						<span class="feature-chip">Swap voices</span>
+						<span class="feature-chip">No middleman</span>
 					</div>
 				</div>
+			</div>
+		</div>
+	</section>
+
+	<!-- Everything in the vessel — bento -->
+	<section class="bg-white dark:bg-[#0a0a0a] border-t border-black/5 dark:border-white/5 py-24 md:py-32">
+		<div class="max-w-7xl mx-auto px-6">
+			<div class="text-center mb-16 md:mb-20">
+				<p use:reveal class="reveal eyebrow justify-center mb-5">The whole kit</p>
+				<h2
+					use:reveal={60}
+					class="reveal text-3xl md:text-4xl lg:text-5xl font-semibold text-[#1a1a1a] dark:text-[#fafafa] tracking-tight text-balance"
+					style="font-family: 'Exo 2', sans-serif;"
+				>
+					Everything packed into the vessel.
+				</h2>
+			</div>
+
+			<div class="grid md:grid-cols-2 lg:grid-cols-3 gap-5 lg:gap-6">
+				{#each bento as item, i}
+					<div use:reveal={(i % 3) * 90} class="reveal bento-tile">
+						<div class="bento-icon">
+							<Icon name={item.icon} size={22} class="text-white" />
+						</div>
+						<h3 class="text-lg font-semibold text-[#1a1a1a] dark:text-[#fafafa] mt-5 mb-2 tracking-tight">
+							{item.title}
+						</h3>
+						<p class="text-sm text-black/55 dark:text-white/55 leading-relaxed text-pretty">
+							{item.body}
+						</p>
+					</div>
+				{/each}
 			</div>
 		</div>
 	</section>
 
 	<!-- Latest Updates (Blog) -->
 	{#if data.posts.length > 0}
-		<section class="bg-white border-t border-black/5 py-24 md:py-32">
+		<section class="bg-[#f5f7fa] dark:bg-[#101013] border-t border-black/5 dark:border-white/5 py-24 md:py-32">
 			<div class="max-w-7xl mx-auto px-6">
-				<div class="flex items-end justify-between mb-12 md:mb-16">
+				<div use:reveal class="reveal flex items-end justify-between mb-12 md:mb-16">
 					<h2
-						class="text-3xl md:text-4xl font-semibold text-[#1a1a1a] tracking-tight"
+						class="text-3xl md:text-4xl font-semibold text-[#1a1a1a] dark:text-[#fafafa] tracking-tight"
 						style="font-family: 'Exo 2', sans-serif;"
 					>
 						Latest updates
@@ -425,8 +452,8 @@
 				</div>
 
 				<div class="grid md:grid-cols-3 gap-6 lg:gap-8">
-					{#each data.posts as post}
-						<a href="/blog/{post.slug}" class="blog-card group">
+					{#each data.posts as post, i}
+						<a use:reveal={(i % 3) * 90} href="/blog/{post.slug}" class="reveal blog-card group">
 							<div class="blog-card-image">
 								<img src={post.image} alt={post.title} loading="lazy" />
 							</div>
@@ -435,15 +462,15 @@
 									<time datetime={post.date} class="text-[#01B2FF]">
 										{formatDate(post.date)}
 									</time>
-									<span class="text-black/25">&middot;</span>
-									<span class="text-black/40">CJ Dyas</span>
+									<span class="text-black/25 dark:text-white/30">&middot;</span>
+									<span class="text-black/40 dark:text-white/40">CJ Dyas</span>
 								</div>
 								<h3
-									class="text-base font-semibold text-[#1a1a1a] group-hover:text-[#01B2FF] transition-colors tracking-tight"
+									class="text-base font-semibold text-[#1a1a1a] dark:text-[#fafafa] group-hover:text-[#01B2FF] transition-colors tracking-tight"
 								>
 									{post.title}
 								</h3>
-								<p class="text-sm text-black/50 leading-relaxed line-clamp-2">
+								<p class="text-sm text-black/50 dark:text-white/50 leading-relaxed line-clamp-2">
 									{post.description}
 								</p>
 							</div>
@@ -484,18 +511,27 @@
 		<div
 			class="absolute inset-0 bg-[radial-gradient(circle_at_center,_var(--tw-gradient-stops))] from-white/20 via-transparent to-transparent opacity-50"
 		></div>
+		<div class="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
+			<span class="aero-bubble" style="--size:160px; --x:12%; --y:55%; --dur:19s; --delay:-3s;"></span>
+			<span class="aero-bubble" style="--size:80px;  --x:82%; --y:30%; --dur:14s; --delay:-7s;"></span>
+			<span class="aero-bubble" style="--size:50px;  --x:68%; --y:70%; --dur:12s; --delay:-1s;"></span>
+		</div>
 
 		<div
 			class="relative z-10 flex flex-col items-center justify-center text-center max-w-7xl mx-auto px-6 py-32 md:py-48"
 		>
 			<img
+				use:reveal
 				src="/brand-assets/logo.svg"
 				alt="Utsuwa"
-				class="hero-logo mb-4"
+				class="reveal hero-logo mb-5"
 			/>
-			<div class="flex flex-wrap items-center justify-center gap-3 mb-6">
+			<p use:reveal={80} class="reveal text-lg md:text-xl text-white/85 text-balance max-w-xl mb-8">
+				Open it once and it's yours. No sign-up, no catch.
+			</p>
+			<div use:reveal={160} class="reveal flex flex-wrap items-center justify-center gap-3 mb-6">
 				<a
-					href="/app"
+					href={sectionUrl('app')}
 					class="skeu-btn-glass text-sm font-bold px-6 py-3 rounded-full transition-all"
 				>
 					Try Live
@@ -509,14 +545,14 @@
 					Download
 				</a>
 				<a
-					href="/docs"
+					href={sectionUrl('docs')}
 					class="skeu-btn-glass-outline text-sm font-medium px-6 py-3 rounded-full transition-all"
 				>
 					Docs
 				</a>
 			</div>
 
-			<p class="text-sm text-white/60 max-w-sm">
+			<p use:reveal={200} class="reveal text-sm text-white/60 max-w-sm">
 				Desktop app available for macOS 14+ with Apple Silicon. Web app works in any modern
 				browser.
 			</p>
@@ -526,7 +562,7 @@
 	</main>
 
 	<!-- Footer -->
-	<footer class="bg-[#f5f7fa] border-t border-black/5 pt-20 md:pt-24 overflow-hidden">
+	<footer class="bg-[#f5f7fa] dark:bg-[#101013] border-t border-black/5 dark:border-white/5 pt-20 md:pt-24 overflow-hidden">
 		<div class="max-w-7xl mx-auto px-6 mb-24 md:mb-32">
 			<div
 				class="flex flex-col md:flex-row justify-between items-start gap-16 md:gap-12"
@@ -539,40 +575,40 @@
 				<!-- Link columns -->
 				<div class="flex flex-wrap gap-12 sm:gap-24 lg:gap-32">
 					<div class="flex flex-col gap-4 min-w-[120px]">
-						<h3 class="text-xs font-semibold text-black/35 mb-1">Project</h3>
+						<h3 class="text-xs font-semibold text-black/35 dark:text-white/35 mb-1">Project</h3>
 						<a
 							href={GITHUB_REPO}
 							target="_blank"
 							rel="noopener noreferrer"
-							class="text-xs font-medium text-black/60 hover:text-[#01B2FF] transition-colors"
+							class="text-xs font-medium text-black/60 dark:text-white/60 hover:text-[#01B2FF] transition-colors"
 							>GitHub</a
 						>
 						<a
 							href={GITHUB_RELEASES}
 							target="_blank"
 							rel="noopener noreferrer"
-							class="text-xs font-medium text-black/60 hover:text-[#01B2FF] transition-colors"
+							class="text-xs font-medium text-black/60 dark:text-white/60 hover:text-[#01B2FF] transition-colors"
 							>Releases</a
 						>
 						<a
-							href="/docs"
-							class="text-xs font-medium text-black/60 hover:text-[#01B2FF] transition-colors"
+							href={sectionUrl('docs')}
+							class="text-xs font-medium text-black/60 dark:text-white/60 hover:text-[#01B2FF] transition-colors"
 							>Docs</a
 						>
 						<a
 							href="/blog"
-							class="text-xs font-medium text-black/60 hover:text-[#01B2FF] transition-colors"
+							class="text-xs font-medium text-black/60 dark:text-white/60 hover:text-[#01B2FF] transition-colors"
 							>Blog</a
 						>
 					</div>
 
 					<div class="flex flex-col gap-4 min-w-[120px]">
-						<h3 class="text-xs font-semibold text-black/35 mb-1">Legal</h3>
+						<h3 class="text-xs font-semibold text-black/35 dark:text-white/35 mb-1">Legal</h3>
 						<a
 							href={`${GITHUB_REPO}/blob/main/LICENSE`}
 							target="_blank"
 							rel="noopener noreferrer"
-							class="text-xs font-medium text-black/60 hover:text-[#01B2FF] transition-colors"
+							class="text-xs font-medium text-black/60 dark:text-white/60 hover:text-[#01B2FF] transition-colors"
 							>MIT License</a
 						>
 					</div>
@@ -592,12 +628,12 @@
 		</div>
 
 		<!-- Bottom bar -->
-		<div class="w-full border-t border-black/8 bg-[#f5f7fa] relative z-10">
+		<div class="w-full border-t border-black/8 dark:border-white/8 bg-[#f5f7fa] dark:bg-[#101013] relative z-10">
 			<div
 				class="max-w-7xl mx-auto px-6 py-8 md:py-10 flex flex-col md:flex-row justify-between items-center gap-6 md:gap-0"
 			>
 				<div
-					class="text-[11px] text-black/35 font-medium tracking-tight order-2 md:order-1"
+					class="text-[11px] text-black/35 dark:text-white/35 font-medium tracking-tight order-2 md:order-1"
 				>
 					&copy; 2026 Ordinary Company Group LLC. Open source under MIT.
 				</div>
@@ -606,7 +642,7 @@
 						href={GITHUB_REPO}
 						target="_blank"
 						rel="noopener noreferrer"
-						class="text-black/40 hover:text-[#01B2FF] transition-colors"
+						class="text-black/40 dark:text-white/40 hover:text-[#01B2FF] transition-colors"
 						aria-label="GitHub"
 					>
 						<svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor"
@@ -628,58 +664,331 @@
 		filter: brightness(0) invert(1);
 	}
 
+	/* Glass theme toggle in the hero nav (sits on the bright blue gradient) */
+	.nav-theme-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 2rem;
+		height: 2rem;
+		border-radius: 9999px;
+		color: #fff;
+		background: rgba(255, 255, 255, 0.14);
+		backdrop-filter: blur(8px);
+		-webkit-backdrop-filter: blur(8px);
+		border: 1px solid rgba(255, 255, 255, 0.3);
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 0.3),
+			0 2px 6px rgba(0, 0, 0, 0.1);
+		cursor: pointer;
+		transition:
+			transform 0.2s cubic-bezier(0.16, 1, 0.3, 1),
+			background 0.2s ease,
+			border-color 0.2s ease;
+	}
+
+	.nav-theme-btn:hover {
+		background: rgba(255, 255, 255, 0.24);
+		border-color: rgba(255, 255, 255, 0.5);
+		transform: translateY(-1px);
+	}
+
+	.nav-theme-btn:active {
+		transform: translateY(0) scale(0.96);
+	}
+
 	.hero-logo {
 		width: min(80vw, 500px);
 		height: auto;
-		filter: brightness(0) invert(1);
-		drop-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+		filter: brightness(0) invert(1) drop-shadow(0 2px 10px rgba(0, 0, 0, 0.25));
 	}
 
-	.glass-panel {
-		background: linear-gradient(
-			180deg,
-			rgba(255, 255, 255, 0.4) 0%,
-			rgba(255, 255, 255, 0.1) 100%
-		);
+	/* Animated aurora wash over the hero gradient */
+	.hero-aurora {
+		background:
+			radial-gradient(60% 50% at 20% 20%, rgba(255, 255, 255, 0.5) 0%, transparent 60%),
+			radial-gradient(50% 40% at 85% 15%, rgba(180, 240, 255, 0.55) 0%, transparent 55%),
+			radial-gradient(55% 45% at 70% 70%, rgba(255, 255, 255, 0.35) 0%, transparent 60%);
+		opacity: 0.7;
+		animation: auroraDrift 18s ease-in-out infinite alternate;
+		will-change: transform, opacity;
+	}
+
+	@keyframes auroraDrift {
+		0% {
+			transform: translate3d(-3%, -2%, 0) scale(1.05);
+			opacity: 0.55;
+		}
+		100% {
+			transform: translate3d(3%, 2%, 0) scale(1.15);
+			opacity: 0.8;
+		}
+	}
+
+	/* Frutiger Aero glass bubbles */
+	.aero-bubble {
+		position: absolute;
+		left: var(--x);
+		top: var(--y);
+		width: var(--size);
+		height: var(--size);
+		border-radius: 50%;
+		background:
+			radial-gradient(circle at 32% 28%, rgba(255, 255, 255, 0.9) 0%, rgba(255, 255, 255, 0.25) 22%, transparent 45%),
+			linear-gradient(180deg, rgba(255, 255, 255, 0.35) 0%, rgba(1, 178, 255, 0.12) 100%);
+		box-shadow:
+			inset 0 0 20px rgba(255, 255, 255, 0.45),
+			inset 0 -6px 14px rgba(1, 130, 200, 0.25),
+			0 8px 30px rgba(0, 80, 130, 0.15);
+		backdrop-filter: blur(2px);
+		-webkit-backdrop-filter: blur(2px);
+		animation: floatBubble var(--dur, 16s) ease-in-out var(--delay, 0s) infinite alternate;
+		will-change: transform;
+	}
+
+	@keyframes floatBubble {
+		0% {
+			transform: translateY(0) translateX(0) scale(1);
+			opacity: 0.7;
+		}
+		50% {
+			opacity: 0.95;
+		}
+		100% {
+			transform: translateY(-40px) translateX(16px) scale(1.08);
+			opacity: 0.6;
+		}
+	}
+
+	/* Glass eyebrow pill on the blue hero */
+	.glass-pill {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.4rem 0.9rem;
+		border-radius: 9999px;
+		font-size: 0.75rem;
+		font-weight: 600;
+		letter-spacing: 0.01em;
+		color: #fff;
+		background: rgba(255, 255, 255, 0.16);
+		backdrop-filter: blur(10px);
+		-webkit-backdrop-filter: blur(10px);
+		border: 1px solid rgba(255, 255, 255, 0.35);
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 0.4),
+			0 2px 10px rgba(0, 0, 0, 0.1);
+	}
+
+	.glass-pill-dot {
+		width: 0.5rem;
+		height: 0.5rem;
+		border-radius: 50%;
+		background: #fff;
+		box-shadow: 0 0 8px rgba(255, 255, 255, 0.9);
+		animation: pulseDot 2.4s ease-in-out infinite;
+	}
+
+	@keyframes pulseDot {
+		0%, 100% { opacity: 1; transform: scale(1); }
+		50% { opacity: 0.5; transform: scale(0.8); }
+	}
+
+	/* Screenshot frame with 3D tilt + glow ring */
+	.screenshot-stage {
+		perspective: 1600px;
+	}
+
+	.screenshot-frame {
+		position: relative;
+		border: 1px solid rgba(255, 255, 255, 0.5);
+		box-shadow:
+			0 2px 8px rgba(0, 60, 100, 0.12),
+			0 24px 60px rgba(0, 60, 100, 0.28);
+		transition:
+			transform 0.6s cubic-bezier(0.16, 1, 0.3, 1),
+			box-shadow 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+		transform-style: preserve-3d;
+		will-change: transform;
+	}
+
+	.screenshot-stage:hover .screenshot-frame {
+		transform: rotateX(2deg) rotateY(-2.5deg) translateY(-8px) scale(1.01);
+		box-shadow:
+			0 0 0 1px rgba(255, 255, 255, 0.6),
+			0 30px 80px rgba(0, 60, 100, 0.35),
+			0 0 60px rgba(1, 178, 255, 0.25);
+	}
+
+	/* Section eyebrow (editorial label) */
+	.eyebrow {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.6rem;
+		font-size: 0.72rem;
+		font-weight: 700;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		color: #0088cc;
+	}
+
+	.eyebrow-num {
+		font-family: 'Exo 2', sans-serif;
+		font-size: 0.72rem;
+		font-weight: 700;
+		color: #01b2ff;
+		padding: 0.15rem 0.45rem;
+		border-radius: 0.4rem;
+		background: linear-gradient(180deg, rgba(1, 178, 255, 0.14) 0%, rgba(1, 178, 255, 0.06) 100%);
+		border: 1px solid rgba(1, 178, 255, 0.25);
+		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+	}
+
+	/* Feature callout chips */
+	.feature-chip {
+		font-size: 0.78rem;
+		font-weight: 600;
+		color: #0a7bb0;
+		padding: 0.35rem 0.75rem;
+		border-radius: 9999px;
+		background: linear-gradient(180deg, rgba(255, 255, 255, 0.9) 0%, rgba(240, 248, 255, 0.7) 100%);
+		border: 1px solid rgba(1, 178, 255, 0.22);
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 0.8),
+			0 1px 3px rgba(0, 0, 0, 0.05);
+	}
+
+	/* Provider chips */
+	.provider-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 0.85rem;
+		font-weight: 600;
+		color: #1a1a1a;
+		padding: 0.5rem 1.05rem 0.5rem 0.85rem;
+		border-radius: 9999px;
+		background: linear-gradient(180deg, rgba(255, 255, 255, 0.95) 0%, rgba(240, 248, 255, 0.75) 100%);
+		backdrop-filter: blur(8px);
+		-webkit-backdrop-filter: blur(8px);
+		border: 1px solid rgba(1, 178, 255, 0.18);
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 0.9),
+			0 2px 8px rgba(0, 0, 0, 0.05);
+		transition:
+			transform 0.3s cubic-bezier(0.16, 1, 0.3, 1),
+			box-shadow 0.3s cubic-bezier(0.16, 1, 0.3, 1),
+			border-color 0.3s ease;
+	}
+
+	.provider-chip:hover {
+		transform: translateY(-2px);
+		border-color: rgba(1, 178, 255, 0.4);
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 1),
+			0 0 16px rgba(1, 178, 255, 0.15),
+			0 6px 18px rgba(0, 0, 0, 0.08);
+	}
+
+	/* Stat tiles */
+	.stat-tile {
+		text-align: center;
+		padding: 1rem 0.75rem;
+		border-radius: 1rem;
+		background: linear-gradient(165deg, rgba(255, 255, 255, 0.9) 0%, rgba(240, 248, 255, 0.7) 100%);
 		backdrop-filter: blur(12px);
 		-webkit-backdrop-filter: blur(12px);
-		border: 1px solid rgba(255, 255, 255, 0.3);
+		border: 1px solid rgba(255, 255, 255, 0.6);
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 0.9),
+			0 4px 16px rgba(0, 60, 100, 0.1);
 	}
 
-	.skeu-icon {
-		background: linear-gradient(180deg, #4dd0ff 0%, #01b2ff 40%, #0099dd 100%);
+	.stat-value {
+		font-family: 'Exo 2', sans-serif;
+		font-size: 1.85rem;
+		font-weight: 700;
+		line-height: 1;
+		font-variant-numeric: tabular-nums;
+		background: linear-gradient(180deg, #2bb8ff 0%, #0088cc 100%);
+		-webkit-background-clip: text;
+		background-clip: text;
+		-webkit-text-fill-color: transparent;
+	}
+
+	.stat-label {
+		margin-top: 0.4rem;
+		font-size: 0.72rem;
+		font-weight: 600;
+		letter-spacing: 0.02em;
+		color: rgba(0, 0, 0, 0.45);
+	}
+
+	/* Bento tiles */
+	.bento-tile {
+		padding: 1.6rem;
+		border-radius: 1.25rem;
+		background: linear-gradient(165deg, rgba(255, 255, 255, 0.95) 0%, rgba(240, 248, 255, 0.8) 55%, rgba(1, 178, 255, 0.06) 100%);
+		backdrop-filter: blur(16px);
+		-webkit-backdrop-filter: blur(16px);
+		border: 1px solid rgba(1, 178, 255, 0.16);
 		box-shadow:
-			inset 0 1px 0 rgba(255, 255, 255, 0.4),
-			inset 0 -1px 2px rgba(0, 0, 0, 0.15),
+			inset 0 1px 0 rgba(255, 255, 255, 0.9),
+			0 4px 20px rgba(0, 0, 0, 0.06),
+			0 1px 3px rgba(0, 0, 0, 0.04);
+		transition:
+			transform 0.4s cubic-bezier(0.16, 1, 0.3, 1),
+			box-shadow 0.4s cubic-bezier(0.16, 1, 0.3, 1),
+			border-color 0.4s ease;
+	}
+
+	.bento-tile:hover {
+		transform: translateY(-6px);
+		border-color: rgba(1, 178, 255, 0.4);
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 1),
+			0 0 30px rgba(1, 178, 255, 0.12),
+			0 16px 40px rgba(0, 60, 100, 0.12);
+	}
+
+	/* Glossy skeu icon tile inside bento */
+	.bento-icon {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 3rem;
+		height: 3rem;
+		border-radius: 0.875rem;
+		background: linear-gradient(180deg, #4dd0ff 0%, #01b2ff 45%, #0099dd 100%);
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 0.5),
+			inset 0 -2px 4px rgba(0, 0, 0, 0.15),
 			0 4px 12px rgba(1, 178, 255, 0.4),
-			0 0 20px rgba(1, 178, 255, 0.25);
-		border: 1px solid rgba(255, 255, 255, 0.15);
+			0 0 18px rgba(1, 178, 255, 0.2);
+		border: 1px solid rgba(255, 255, 255, 0.2);
 	}
 
-	.skeu-btn {
-		color: white;
-		background: linear-gradient(180deg, #4dd0ff 0%, #01b2ff 40%, #0099dd 100%);
-		border: 1px solid rgba(0, 0, 0, 0.1);
-		box-shadow:
-			inset 0 1px 0 rgba(255, 255, 255, 0.3),
-			0 2px 6px rgba(1, 178, 255, 0.25);
-		text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15);
+	/* Subtle image outline for depth */
+	.img-outline {
+		outline: 1px solid rgba(0, 0, 0, 0.06);
+		outline-offset: -1px;
 	}
 
-	.skeu-btn:hover {
-		background: linear-gradient(180deg, #5dd8ff 0%, #1abcff 40%, #01a8ee 100%);
-		transform: translateY(-1px);
-		box-shadow:
-			inset 0 1px 0 rgba(255, 255, 255, 0.4),
-			0 0 16px rgba(1, 178, 255, 0.4),
-			0 4px 12px rgba(1, 178, 255, 0.3);
+	/* Scroll-reveal */
+	.reveal {
+		opacity: 0;
+		transform: translateY(26px);
+		transition:
+			opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1),
+			transform 0.7s cubic-bezier(0.16, 1, 0.3, 1);
+		transition-delay: var(--reveal-delay, 0ms);
 	}
 
-	.skeu-btn:active {
-		transform: translateY(0);
-		box-shadow:
-			inset 0 2px 4px rgba(0, 0, 0, 0.2),
-			0 1px 2px rgba(0, 0, 0, 0.1);
+	/* `.revealed` is toggled by the reveal action at runtime, so mark it global
+	   to stop Svelte pruning this rule as "unused". */
+	.reveal:global(.revealed) {
+		opacity: 1;
+		transform: none;
 	}
 
 	.skeu-btn-sm {
@@ -702,22 +1011,10 @@
 	}
 
 	.skeu-btn-sm:active {
-		transform: translateY(0);
+		transform: translateY(0) scale(0.97);
 		box-shadow:
 			inset 0 2px 3px rgba(0, 0, 0, 0.2),
 			0 1px 2px rgba(0, 0, 0, 0.1);
-	}
-
-	/* Skeuomorphic badge */
-	.skeu-badge {
-		color: #0088cc;
-		background: linear-gradient(180deg, rgba(1, 178, 255, 0.12) 0%, rgba(1, 178, 255, 0.06) 100%);
-		border: 1px solid rgba(1, 178, 255, 0.25);
-		box-shadow:
-			inset 0 1px 0 rgba(255, 255, 255, 0.6),
-			inset 0 -1px 0 rgba(0, 0, 0, 0.04),
-			0 2px 6px rgba(1, 178, 255, 0.1),
-			0 0 10px rgba(1, 178, 255, 0.05);
 	}
 
 	/* Glass buttons for blue backgrounds */
@@ -744,7 +1041,7 @@
 	}
 
 	.skeu-btn-glass:active {
-		transform: translateY(0);
+		transform: translateY(0) scale(0.97);
 		background: linear-gradient(180deg, #e8e8e8 0%, #ddd 100%);
 		box-shadow:
 			inset 0 2px 4px rgba(0, 0, 0, 0.1),
@@ -773,22 +1070,11 @@
 	}
 
 	.skeu-btn-glass-outline:active {
-		transform: translateY(0);
+		transform: translateY(0) scale(0.97);
 		background: rgba(255, 255, 255, 0.08);
 		box-shadow:
 			inset 0 2px 4px rgba(0, 0, 0, 0.15),
 			0 1px 2px rgba(0, 0, 0, 0.1);
-	}
-
-	/* Skeuomorphic card (dark) */
-	.skeu-card {
-		background: linear-gradient(180deg, #141414 0%, #0d0d0d 100%);
-		border: 1px solid rgba(255, 255, 255, 0.08);
-		box-shadow:
-			inset 0 1px 0 rgba(255, 255, 255, 0.04),
-			inset 0 -1px 0 rgba(0, 0, 0, 0.3),
-			0 4px 16px rgba(0, 0, 0, 0.3),
-			0 1px 3px rgba(0, 0, 0, 0.2);
 	}
 
 	/* Skeuomorphic card (light) — Frutiger Aero glass */
@@ -809,24 +1095,11 @@
 			0 1px 3px rgba(0, 0, 0, 0.05);
 	}
 
-	.footer-brand-logo {
-		height: 1.25rem;
-		width: auto;
-		filter: brightness(0) invert(1);
-	}
-
 	.footer-brand-logo-light {
 		height: 1.25rem;
 		width: auto;
 		filter: brightness(0);
 		opacity: 0.7;
-	}
-
-	.footer-giant-logo {
-		width: 80vw;
-		max-width: 1200px;
-		height: auto;
-		filter: brightness(0) invert(1);
 	}
 
 	.footer-giant-logo-light {
@@ -919,5 +1192,154 @@
 		flex: 1;
 		position: relative;
 		z-index: 2;
+	}
+
+	/* ===== Dark mode (matches the app/docs #0a0a0a theme) =====
+	   The hero keeps its bright blue gradient; everything below goes dark glass. */
+	:global(.dark) .skeu-card-light {
+		background: linear-gradient(
+			165deg,
+			rgba(40, 44, 52, 0.7) 0%,
+			rgba(20, 24, 32, 0.6) 50%,
+			rgba(1, 178, 255, 0.08) 100%
+		);
+		border-color: rgba(1, 178, 255, 0.18);
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 0.07),
+			inset 0 -1px 0 rgba(0, 0, 0, 0.3),
+			0 4px 20px rgba(0, 0, 0, 0.4),
+			0 1px 3px rgba(0, 0, 0, 0.3);
+	}
+
+	:global(.dark) .provider-chip {
+		color: #eef4f8;
+		background: linear-gradient(180deg, rgba(40, 44, 52, 0.85) 0%, rgba(22, 26, 34, 0.7) 100%);
+		border-color: rgba(1, 178, 255, 0.22);
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 0.08),
+			0 2px 8px rgba(0, 0, 0, 0.35);
+	}
+
+	:global(.dark) .provider-chip:hover {
+		border-color: rgba(1, 178, 255, 0.5);
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 0.12),
+			0 0 16px rgba(1, 178, 255, 0.25),
+			0 6px 18px rgba(0, 0, 0, 0.4);
+	}
+
+	:global(.dark) .feature-chip {
+		color: #7fd8ff;
+		background: linear-gradient(180deg, rgba(40, 44, 52, 0.8) 0%, rgba(22, 26, 34, 0.6) 100%);
+		border-color: rgba(1, 178, 255, 0.25);
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 0.07),
+			0 1px 3px rgba(0, 0, 0, 0.3);
+	}
+
+	:global(.dark) .stat-tile {
+		background: linear-gradient(165deg, rgba(40, 44, 52, 0.7) 0%, rgba(22, 26, 34, 0.55) 100%);
+		border-color: rgba(255, 255, 255, 0.1);
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 0.08),
+			0 4px 16px rgba(0, 0, 0, 0.4);
+	}
+
+	:global(.dark) .stat-label {
+		color: rgba(255, 255, 255, 0.5);
+	}
+
+	:global(.dark) .bento-tile {
+		background: linear-gradient(
+			165deg,
+			rgba(40, 44, 52, 0.7) 0%,
+			rgba(20, 24, 32, 0.6) 55%,
+			rgba(1, 178, 255, 0.07) 100%
+		);
+		border-color: rgba(1, 178, 255, 0.18);
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 0.07),
+			0 4px 20px rgba(0, 0, 0, 0.4),
+			0 1px 3px rgba(0, 0, 0, 0.3);
+	}
+
+	:global(.dark) .bento-tile:hover {
+		border-color: rgba(1, 178, 255, 0.45);
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 0.12),
+			0 0 30px rgba(1, 178, 255, 0.18),
+			0 16px 40px rgba(0, 0, 0, 0.5);
+	}
+
+	:global(.dark) .eyebrow {
+		color: #4dd0ff;
+	}
+
+	:global(.dark) .blog-card {
+		background: linear-gradient(
+			165deg,
+			rgba(40, 44, 52, 0.8) 0%,
+			rgba(20, 24, 32, 0.65) 50%,
+			rgba(1, 178, 255, 0.08) 100%
+		);
+		border-color: rgba(1, 178, 255, 0.2);
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 0.08),
+			inset 0 -1px 0 rgba(0, 0, 0, 0.3),
+			0 4px 20px rgba(0, 0, 0, 0.4),
+			0 1px 4px rgba(0, 0, 0, 0.3);
+	}
+
+	:global(.dark) .blog-card::before {
+		background: linear-gradient(180deg, rgba(255, 255, 255, 0.08) 0%, transparent 100%);
+	}
+
+	:global(.dark) .blog-card:hover {
+		border-color: rgba(1, 178, 255, 0.45);
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 0.14),
+			0 0 30px rgba(1, 178, 255, 0.18),
+			0 8px 32px rgba(1, 178, 255, 0.12),
+			0 20px 48px rgba(0, 0, 0, 0.5);
+	}
+
+	:global(.dark) .blog-card-image {
+		background: linear-gradient(135deg, #1a1f28 0%, #12161d 100%);
+	}
+
+	:global(.dark) .img-outline {
+		outline-color: rgba(255, 255, 255, 0.08);
+	}
+
+	:global(.dark) .footer-brand-logo-light {
+		filter: brightness(0) invert(1);
+		opacity: 0.7;
+	}
+
+	:global(.dark) .footer-giant-logo-light {
+		filter: brightness(0) invert(1);
+		opacity: 0.06;
+	}
+
+	/* Respect reduced motion across the whole page */
+	@media (prefers-reduced-motion: reduce) {
+		.reveal {
+			opacity: 1;
+			transform: none;
+			transition: none;
+		}
+
+		.hero-aurora,
+		.aero-bubble,
+		.glass-pill-dot {
+			animation: none;
+		}
+
+		.screenshot-stage:hover .screenshot-frame,
+		.bento-tile:hover,
+		.provider-chip:hover,
+		.blog-card:hover {
+			transform: none;
+		}
 	}
 </style>

--- a/src/routes/app/settings/+layout.svelte
+++ b/src/routes/app/settings/+layout.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import { Icon } from '$lib/components/ui';
+	import { localPath } from '$lib/config/links';
 
 	let { children } = $props();
 
-	const navItems = [
-		{ href: '/app/settings/persona', label: 'Character', icon: 'persona' },
-		{ href: '/app/settings/display', label: 'Display', icon: 'monitor' },
-		{ href: '/app/settings/data', label: 'Data', icon: 'database' },
-		{ href: '/app/settings/developer', label: 'Developer', icon: 'code' }
-	];
+	const navItems = $derived([
+		{ href: localPath('app', '/settings/persona'), label: 'Character', icon: 'persona' },
+		{ href: localPath('app', '/settings/display'), label: 'Display', icon: 'monitor' },
+		{ href: localPath('app', '/settings/data'), label: 'Data', icon: 'database' },
+		{ href: localPath('app', '/settings/developer'), label: 'Developer', icon: 'code' }
+	]);
 
 	const currentIcon = $derived(
 		navItems.find((item) => $page.url.pathname === item.href)?.icon || 'settings'
@@ -20,7 +21,7 @@
 	<!-- Sidebar -->
 	<aside class="sidebar">
 		<div class="sidebar-header">
-			<a href="/app" class="back-button">
+			<a href={localPath('app')} class="back-button">
 				<Icon name="chevron-left" size={20} />
 				<span>Back</span>
 			</a>

--- a/src/routes/app/settings/+page.svelte
+++ b/src/routes/app/settings/+page.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { onMount } from 'svelte';
+	import { localPath } from '$lib/config/links';
 
 	onMount(() => {
-		goto('/app/settings/persona', { replaceState: true });
+		goto(localPath('app', '/settings/persona'), { replaceState: true });
 	});
 </script>
 

--- a/src/routes/app/settings/developer/+page.svelte
+++ b/src/routes/app/settings/developer/+page.svelte
@@ -6,6 +6,7 @@
 	import localforage from 'localforage';
 	import { debugEventsStore, testEvents } from '$lib/stores/debugEvents.svelte';
 	import { goto } from '$app/navigation';
+	import { localPath } from '$lib/config/links';
 
 	// Material debug modes from @pixiv/three-vrm-materials-mtoon
 	const materialDebugModes = [
@@ -233,7 +234,7 @@
 	async function triggerEvent(event: typeof testEvents[0]) {
 		debugEventsStore.trigger(event);
 		// Navigate to home to show the event
-		await goto('/app');
+		await goto(localPath('app'));
 	}
 
 	// Clear all character data

--- a/src/routes/blog/+layout.svelte
+++ b/src/routes/blog/+layout.svelte
@@ -1,24 +1,21 @@
 <script lang="ts">
-	import { lightVars, applyVars } from '$lib/config/docs-theme';
+	import { setupThemeWatcher } from '$lib/config/docs-theme';
+	import { cycleTheme, getIconName, getLabel } from '$lib/config/docs-theme-toggle.svelte';
+	import Icon from '$lib/components/ui/Icon.svelte';
 	import { browser } from '$app/environment';
 	import { page } from '$app/state';
 	import { GITHUB_REPO } from '$lib/config/site';
+	import { sectionUrl, isSection } from '$lib/config/links';
 
 	let { children } = $props();
 	let blogEl = $state<HTMLDivElement | null>(null);
 
 	const currentPath = $derived(page.url.pathname);
+	const themeIcon = $derived(getIconName());
+	const themeLabel = $derived(getLabel());
 
-	$effect(() => {
-		const el = blogEl;
-		if (!el || !browser) return;
-		applyVars(el, lightVars);
-		document.documentElement.setAttribute('data-docs-theme', 'light');
-
-		return () => {
-			document.documentElement.removeAttribute('data-docs-theme');
-		};
-	});
+	// Sync with the shared colorMode/.dark toggle (same as the docs).
+	$effect(() => setupThemeWatcher(() => blogEl, browser));
 </script>
 
 <div class="docs blog-site" bind:this={blogEl}>
@@ -29,12 +26,23 @@
 		</a>
 
 		<div class="nav-links">
-			<a href="/docs" class="nav-link" class:active={currentPath.startsWith('/docs')}>Docs</a>
+			<a href={sectionUrl('docs')} class="nav-link" class:active={isSection('docs')}>Docs</a>
 			<a href="/blog" class="nav-link" class:active={currentPath.startsWith('/blog')}>Blog</a>
 			<a href={GITHUB_REPO} target="_blank" rel="noopener noreferrer" class="nav-link">GitHub</a>
 		</div>
 
-		<a href="/app" class="nav-cta">Try Live</a>
+		<div class="nav-right">
+			<button
+				type="button"
+				class="nav-theme-btn"
+				onclick={cycleTheme}
+				aria-label={`Theme: ${themeLabel}`}
+				title={themeLabel}
+			>
+				<Icon name={themeIcon} size={16} />
+			</button>
+			<a href={sectionUrl('app')} class="nav-cta">Try Live</a>
+		</div>
 	</nav>
 
 	<main class="blog-main" data-pagefind-body>
@@ -53,7 +61,7 @@
 						<h3>Project</h3>
 						<a href={GITHUB_REPO} target="_blank" rel="noopener noreferrer">GitHub</a>
 						<a href={`${GITHUB_REPO}/releases`} target="_blank" rel="noopener noreferrer">Releases</a>
-						<a href="/docs">Docs</a>
+						<a href={sectionUrl('docs')}>Docs</a>
 						<a href="/blog">Blog</a>
 					</div>
 					<div class="footer-col">
@@ -75,8 +83,11 @@
 <style>
 	.blog-site {
 		min-height: 100vh;
-		background: white;
-		color: #1a1a1a;
+		/* Ambient Frutiger Aero blue glow at the top, over the themed background */
+		background:
+			radial-gradient(62% 32% at 50% 0%, var(--docs-glow) 0%, transparent 70%),
+			var(--docs-bg);
+		color: var(--docs-text);
 		font-family: 'M PLUS Rounded 1c', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 	}
 
@@ -99,8 +110,8 @@
 	.nav-logo {
 		height: 1.125rem;
 		width: auto;
-		filter: brightness(0);
-		opacity: 0.8;
+		filter: var(--docs-logo-filter, none);
+		opacity: 0.85;
 	}
 
 	.nav-links {
@@ -111,17 +122,54 @@
 
 	.nav-link {
 		font-size: 0.875rem;
-		color: rgba(0, 0, 0, 0.5);
+		color: var(--docs-text-muted);
 		text-decoration: none;
 		transition: color 0.15s ease;
 	}
 
 	.nav-link:hover {
-		color: #1a1a1a;
+		color: var(--docs-text);
 	}
 
 	.nav-link.active {
-		color: #01B2FF;
+		color: var(--docs-accent);
+	}
+
+	.nav-right {
+		display: flex;
+		align-items: center;
+		gap: 0.625rem;
+	}
+
+	.nav-theme-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 2rem;
+		height: 2rem;
+		border-radius: 9999px;
+		color: var(--docs-text-muted);
+		background: var(--docs-surface);
+		border: 1px solid var(--docs-border);
+		cursor: pointer;
+		transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+		box-shadow:
+			0 1px 0 var(--docs-inner-highlight) inset,
+			0 2px 4px rgba(0, 0, 0, 0.05);
+	}
+
+	.nav-theme-btn:hover {
+		color: var(--docs-accent);
+		background: var(--docs-surface-solid);
+		border-color: var(--docs-accent);
+		transform: translateY(-1px);
+		box-shadow:
+			0 1px 0 var(--docs-inner-highlight) inset,
+			0 0 12px var(--docs-glow);
+	}
+
+	.nav-theme-btn:active {
+		transform: translateY(0) scale(0.96);
 	}
 
 	.nav-cta {
@@ -131,7 +179,7 @@
 		text-decoration: none;
 		padding: 0.5rem 1rem;
 		border-radius: 9999px;
-		background: linear-gradient(180deg, #4dd0ff 0%, #01b2ff 40%, #0099dd 100%);
+		background: var(--docs-btn-gradient);
 		border: 1px solid rgba(0, 0, 0, 0.1);
 		box-shadow:
 			inset 0 1px 0 rgba(255, 255, 255, 0.3),
@@ -141,7 +189,7 @@
 	}
 
 	.nav-cta:hover {
-		background: linear-gradient(180deg, #5dd8ff 0%, #1abcff 40%, #01a8ee 100%);
+		background: var(--docs-btn-gradient-hover);
 		transform: translateY(-1px);
 		box-shadow:
 			inset 0 1px 0 rgba(255, 255, 255, 0.4),
@@ -158,8 +206,8 @@
 
 	/* Footer */
 	.blog-footer {
-		border-top: 1px solid rgba(0, 0, 0, 0.05);
-		background: #f5f7fa;
+		border-top: 1px solid var(--docs-border);
+		background: var(--docs-bg-solid);
 	}
 
 	.footer-inner {
@@ -178,7 +226,7 @@
 	.footer-brand-logo {
 		height: 1.25rem;
 		width: auto;
-		filter: brightness(0);
+		filter: var(--docs-logo-filter, none);
 		opacity: 0.7;
 	}
 
@@ -197,22 +245,23 @@
 	.footer-col h3 {
 		font-size: 0.6875rem;
 		font-weight: 600;
-		color: rgba(0, 0, 0, 0.35);
+		color: var(--docs-text-muted);
 		text-transform: uppercase;
 		letter-spacing: 0.05em;
 		margin: 0 0 0.25rem 0;
+		opacity: 0.7;
 	}
 
 	.footer-col a {
 		font-size: 0.75rem;
 		font-weight: 500;
-		color: rgba(0, 0, 0, 0.6);
+		color: var(--docs-text-muted);
 		text-decoration: none;
 		transition: color 0.15s ease;
 	}
 
 	.footer-col a:hover {
-		color: #01B2FF;
+		color: var(--docs-accent);
 	}
 
 	.footer-bottom {
@@ -222,22 +271,23 @@
 		max-width: 80rem;
 		margin: 0 auto;
 		padding: 1.5rem;
-		border-top: 1px solid rgba(0, 0, 0, 0.06);
+		border-top: 1px solid var(--docs-border);
 	}
 
 	.footer-bottom span {
 		font-size: 0.6875rem;
-		color: rgba(0, 0, 0, 0.35);
+		color: var(--docs-text-muted);
 		font-weight: 500;
+		opacity: 0.8;
 	}
 
 	.footer-bottom a {
-		color: rgba(0, 0, 0, 0.4);
+		color: var(--docs-text-muted);
 		transition: color 0.15s ease;
 	}
 
 	.footer-bottom a:hover {
-		color: #01B2FF;
+		color: var(--docs-accent);
 	}
 
 	@media (max-width: 768px) {

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -75,15 +75,19 @@
 	.blog-title {
 		font-size: 2.5rem;
 		font-weight: 700;
-		color: #1a1a1a;
 		margin: 0 0 0.5rem 0;
 		letter-spacing: -0.03em;
 		font-family: 'Exo 2', sans-serif;
+		background: linear-gradient(118deg, var(--docs-text) 45%, var(--docs-accent) 100%);
+		-webkit-background-clip: text;
+		background-clip: text;
+		-webkit-text-fill-color: transparent;
+		color: var(--docs-text);
 	}
 
 	.blog-subtitle {
 		font-size: 1rem;
-		color: rgba(0, 0, 0, 0.5);
+		color: var(--docs-text-muted);
 		margin: 0 0 2.5rem 0;
 	}
 
@@ -199,7 +203,7 @@
 	.card-body .card-author {
 		font-size: 0.75rem;
 		font-weight: 600;
-		color: rgba(0, 0, 0, 0.4);
+		color: var(--docs-text-muted);
 	}
 
 	.featured-content time {
@@ -225,6 +229,7 @@
 		max-width: 640px;
 		display: -webkit-box;
 		-webkit-line-clamp: 2;
+		line-clamp: 2;
 		-webkit-box-orient: vertical;
 		overflow: hidden;
 	}
@@ -323,31 +328,76 @@
 	.card-body time {
 		font-size: 0.75rem;
 		font-weight: 600;
-		color: #01B2FF;
+		color: var(--docs-accent);
 	}
 
 	.card-body h2 {
 		font-size: 1.125rem;
 		font-weight: 600;
-		color: #1a1a1a;
+		color: var(--docs-text);
 		margin: 0;
 		transition: color 0.15s ease;
 		line-height: 1.4;
 	}
 
 	.blog-card:hover .card-body h2 {
-		color: #01B2FF;
+		color: var(--docs-accent);
 	}
 
 	.card-body p {
 		font-size: 0.8125rem;
-		color: rgba(0, 0, 0, 0.5);
+		color: var(--docs-text-muted);
 		line-height: 1.6;
 		margin: 0;
 		display: -webkit-box;
 		-webkit-line-clamp: 3;
+		line-clamp: 3;
 		-webkit-box-orient: vertical;
 		overflow: hidden;
+	}
+
+	/* ===== Dark mode glass ===== */
+	:global(.dark) .featured-card,
+	:global(.dark) .blog-card {
+		background: linear-gradient(
+			165deg,
+			rgba(40, 44, 52, 0.8) 0%,
+			rgba(20, 24, 32, 0.65) 50%,
+			rgba(1, 178, 255, 0.08) 100%
+		);
+		border-color: rgba(1, 178, 255, 0.2);
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 0.08),
+			inset 0 -1px 0 rgba(0, 0, 0, 0.3),
+			0 6px 26px rgba(0, 0, 0, 0.4),
+			0 1px 4px rgba(0, 0, 0, 0.3);
+	}
+
+	:global(.dark) .featured-shine,
+	:global(.dark) .blog-card::before {
+		background: linear-gradient(180deg, rgba(255, 255, 255, 0.1) 0%, transparent 100%);
+	}
+
+	:global(.dark) .featured-card:hover {
+		border-color: rgba(1, 178, 255, 0.45);
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 0.14),
+			0 0 40px rgba(1, 178, 255, 0.18),
+			0 12px 48px rgba(1, 178, 255, 0.1),
+			0 24px 64px rgba(0, 0, 0, 0.5);
+	}
+
+	:global(.dark) .blog-card:hover {
+		border-color: rgba(1, 178, 255, 0.45);
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 0.14),
+			0 0 30px rgba(1, 178, 255, 0.18),
+			0 8px 32px rgba(1, 178, 255, 0.12),
+			0 20px 48px rgba(0, 0, 0, 0.5);
+	}
+
+	:global(.dark) .card-image {
+		background: linear-gradient(135deg, #1a1f28 0%, #12161d 100%);
 	}
 
 	@media (max-width: 640px) {

--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -92,25 +92,26 @@
 		gap: 0.375rem;
 		font-size: 0.8125rem;
 		font-weight: 600;
-		color: rgba(0, 0, 0, 0.5);
+		color: var(--docs-text-muted);
 		text-decoration: none;
 		padding: 0.5rem 1rem;
 		border-radius: 0.625rem;
 		transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
 		margin-bottom: 1.25rem;
-		background: linear-gradient(180deg, #ffffff 0%, #f5f5f5 100%);
-		border: 1px solid rgba(0, 0, 0, 0.08);
+		background: var(--docs-surface);
+		border: 1px solid var(--docs-border);
 		box-shadow:
-			inset 0 1px 0 rgba(255, 255, 255, 0.8),
+			inset 0 1px 0 var(--docs-inner-highlight),
 			0 2px 4px rgba(0, 0, 0, 0.06);
 	}
 
 	.back-link:hover {
-		color: #01B2FF;
-		border-color: rgba(1, 178, 255, 0.3);
+		color: var(--docs-accent);
+		border-color: var(--docs-accent);
+		background: var(--docs-surface-solid);
 		box-shadow:
-			inset 0 1px 0 rgba(255, 255, 255, 0.9),
-			0 0 12px rgba(1, 178, 255, 0.12),
+			inset 0 1px 0 var(--docs-inner-highlight),
+			0 0 12px var(--docs-glow),
 			0 2px 8px rgba(0, 0, 0, 0.08);
 		transform: translateY(-1px);
 	}
@@ -118,18 +119,18 @@
 	.back-link:active {
 		transform: translateY(0);
 		box-shadow:
-			inset 0 2px 4px rgba(0, 0, 0, 0.06),
-			0 0 8px rgba(1, 178, 255, 0.08);
+			inset 0 2px 4px var(--docs-inner-shadow),
+			0 0 8px var(--docs-glow);
 	}
 
 	.blog-banner {
 		border-radius: 1rem;
 		overflow: hidden;
 		margin-bottom: 2rem;
-		border: 1px solid rgba(0, 0, 0, 0.08);
+		border: 1px solid var(--docs-glass-border);
 		box-shadow:
-			inset 0 1px 0 rgba(255, 255, 255, 0.8),
-			0 4px 16px rgba(0, 0, 0, 0.08);
+			inset 0 1px 0 var(--docs-inner-highlight),
+			0 4px 16px rgba(0, 0, 0, 0.12);
 	}
 
 	.blog-banner img {
@@ -149,18 +150,19 @@
 	.blog-post-date {
 		font-size: 0.8125rem;
 		font-weight: 500;
-		color: #01B2FF;
+		color: var(--docs-accent);
 	}
 
 	.blog-post-meta .blog-post-date::after {
 		content: '\00b7';
 		margin-left: 0.5rem;
-		color: rgba(0, 0, 0, 0.25);
+		color: var(--docs-text-muted);
+		opacity: 0.6;
 	}
 
 	.blog-post-author {
 		font-size: 0.8125rem;
 		font-weight: 500;
-		color: rgba(0, 0, 0, 0.5);
+		color: var(--docs-text-muted);
 	}
 </style>

--- a/src/routes/docs/+layout.svelte
+++ b/src/routes/docs/+layout.svelte
@@ -74,6 +74,7 @@
 	}
 
 	.docs-main {
+		position: relative;
 		flex: 1;
 		min-width: 0;
 		background: var(--docs-surface-solid);
@@ -83,6 +84,26 @@
 		overflow-y: auto;
 		scrollbar-width: thin;
 		scrollbar-color: transparent transparent;
+	}
+
+	/* Ambient Frutiger Aero blue glow at the top of the content surface */
+	.docs-main::before {
+		content: '';
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		height: 280px;
+		background: radial-gradient(72% 100% at 50% 0%, var(--docs-glow) 0%, transparent 72%);
+		opacity: 0.5;
+		pointer-events: none;
+		z-index: 0;
+	}
+
+	/* Keep page content above the glow */
+	.docs-main > :global(*) {
+		position: relative;
+		z-index: 1;
 	}
 
 	.docs-main:hover {

--- a/src/routes/docs/+page.svelte
+++ b/src/routes/docs/+page.svelte
@@ -1,0 +1,350 @@
+<script lang="ts">
+	import Icon from '$lib/components/ui/Icon.svelte';
+	import DocsSearch from '$lib/components/docs/DocsSearch.svelte';
+	import DocsGetStartedCards from '$lib/components/docs/DocsGetStartedCards.svelte';
+	import { DOCS_URL } from '$lib/config/site';
+	import { localPath } from '$lib/config/links';
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+</script>
+
+<svelte:head>
+	<title>Documentation - Utsuwa</title>
+	<meta
+		name="description"
+		content="Guides, setup, and architecture docs for Utsuwa — the open-source AI companion with 3D VRM avatars, voice, and semantic memory."
+	/>
+	<link rel="canonical" href={DOCS_URL} />
+	<meta property="og:title" content="Utsuwa Documentation" />
+	<meta property="og:type" content="website" />
+	<meta property="og:url" content={DOCS_URL} />
+</svelte:head>
+
+<div class="docs-home" data-pagefind-ignore>
+	<header class="home-hero">
+		<div class="hero-bubbles" aria-hidden="true">
+			<span class="doc-bubble" style="--size:70px;  --x:7%;  --y:20%; --dur:15s; --delay:-2s;"></span>
+			<span class="doc-bubble" style="--size:120px; --x:84%; --y:14%; --dur:21s; --delay:-7s;"></span>
+			<span class="doc-bubble" style="--size:40px;  --x:70%; --y:62%; --dur:12s; --delay:-4s;"></span>
+			<span class="doc-bubble" style="--size:54px;  --x:18%; --y:70%; --dur:17s; --delay:-9s;"></span>
+		</div>
+		<p class="eyebrow">Documentation</p>
+		<h1 class="home-title">Everything you need to run your vessel.</h1>
+		<p class="home-lead">
+			Guides, setup walkthroughs, and a look under the hood. Search the docs or jump straight to a
+			section below.
+		</p>
+		<div class="home-search">
+			<DocsSearch id="docs-home-search" />
+		</div>
+	</header>
+
+	<section class="home-section">
+		<h2 class="section-heading">Get started</h2>
+		<DocsGetStartedCards />
+	</section>
+
+	<section class="home-section">
+		<h2 class="section-heading">Browse the docs</h2>
+		<div class="section-grid">
+			{#each data.sections as section}
+				<div class="section-panel">
+					<div class="panel-head">
+						<div class="panel-icon">
+							<Icon name={section.icon} size={18} />
+							<div class="panel-icon-shine"></div>
+						</div>
+						<h3 class="panel-title">{section.title}</h3>
+					</div>
+					<ul class="panel-list">
+						{#each section.items as item}
+							<li>
+								<a href={localPath('docs', `/${item.slug}`)} class="panel-link">
+									<span class="link-title">
+										{item.title}
+										<Icon name="arrow-right" size={13} />
+									</span>
+									{#if item.description}
+										<span class="link-desc">{item.description}</span>
+									{/if}
+								</a>
+							</li>
+						{/each}
+					</ul>
+				</div>
+			{/each}
+		</div>
+	</section>
+</div>
+
+<style>
+	.docs-home {
+		max-width: 60rem;
+		margin: 0 auto;
+		padding: 3rem 2.5rem 4rem;
+	}
+
+	/* Hero */
+	.home-hero {
+		position: relative;
+		text-align: center;
+		margin-bottom: 3.5rem;
+		padding-top: 1rem;
+	}
+
+	/* Keep hero content above the decorative bubbles */
+	.home-hero > :not(.hero-bubbles) {
+		position: relative;
+		z-index: 1;
+	}
+
+	/* Frutiger Aero glass bubbles, clipped to the hero, behind content */
+	.hero-bubbles {
+		position: absolute;
+		inset: -1rem 0 0;
+		overflow: hidden;
+		pointer-events: none;
+		z-index: 0;
+	}
+
+	.doc-bubble {
+		position: absolute;
+		left: var(--x);
+		top: var(--y);
+		width: var(--size);
+		height: var(--size);
+		border-radius: 50%;
+		background:
+			radial-gradient(circle at 32% 28%, rgba(255, 255, 255, 0.9) 0%, rgba(255, 255, 255, 0.2) 24%, transparent 46%),
+			linear-gradient(180deg, rgba(120, 215, 255, 0.3) 0%, rgba(1, 178, 255, 0.12) 100%);
+		box-shadow:
+			inset 0 0 16px rgba(255, 255, 255, 0.4),
+			inset 0 -5px 12px rgba(1, 130, 200, 0.22),
+			0 6px 24px rgba(0, 120, 190, 0.12);
+		opacity: 0.55;
+		animation: docFloat var(--dur, 16s) ease-in-out var(--delay, 0s) infinite alternate;
+		will-change: transform;
+	}
+
+	@keyframes docFloat {
+		0% {
+			transform: translateY(0) translateX(0) scale(1);
+		}
+		100% {
+			transform: translateY(-30px) translateX(12px) scale(1.07);
+		}
+	}
+
+	.eyebrow {
+		font-size: 0.72rem;
+		font-weight: 700;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		color: var(--docs-accent);
+		margin: 0 0 0.85rem;
+	}
+
+	.home-title {
+		font-family: 'Exo 2', sans-serif;
+		font-size: clamp(2rem, 4vw, 3rem);
+		font-weight: 700;
+		line-height: 1.05;
+		letter-spacing: -0.01em;
+		text-wrap: balance;
+		margin: 0 0 1rem;
+		background: linear-gradient(118deg, var(--docs-text) 38%, var(--docs-accent) 100%);
+		-webkit-background-clip: text;
+		background-clip: text;
+		-webkit-text-fill-color: transparent;
+		color: var(--docs-text);
+	}
+
+	.home-lead {
+		font-size: 1.05rem;
+		line-height: 1.6;
+		color: var(--docs-text-muted);
+		max-width: 34rem;
+		margin: 0 auto 1.75rem;
+		text-wrap: pretty;
+	}
+
+	.home-search {
+		position: relative;
+		max-width: 30rem;
+		margin: 0 auto;
+	}
+
+	/* Soft glow halo behind the search box */
+	.home-search::before {
+		content: '';
+		position: absolute;
+		inset: -55% -12%;
+		background: radial-gradient(50% 60% at 50% 50%, var(--docs-glow) 0%, transparent 70%);
+		opacity: 0.7;
+		pointer-events: none;
+		z-index: 0;
+	}
+
+	.home-search :global(.search-container) {
+		position: relative;
+		z-index: 1;
+	}
+
+	/* Sections */
+	.home-section {
+		margin-top: 3rem;
+	}
+
+	.section-heading {
+		font-family: 'Exo 2', sans-serif;
+		font-size: 1.35rem;
+		font-weight: 600;
+		color: var(--docs-text);
+		margin: 0 0 1.25rem;
+	}
+
+	.section-grid {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		gap: 1.25rem;
+	}
+
+	.section-panel {
+		border: 1px solid var(--docs-glass-border);
+		border-radius: 1rem;
+		padding: 1.5rem;
+		background: var(--docs-glass-bg);
+		backdrop-filter: blur(12px);
+		-webkit-backdrop-filter: blur(12px);
+		transition: all 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+		box-shadow:
+			0 1px 0 var(--docs-inner-highlight) inset,
+			0 4px 16px rgba(0, 0, 0, 0.08);
+	}
+
+	.section-panel:hover {
+		border-color: var(--docs-accent);
+		box-shadow:
+			0 1px 0 var(--docs-inner-highlight) inset,
+			0 0 20px var(--docs-glow),
+			0 8px 28px rgba(0, 0, 0, 0.1);
+	}
+
+	.panel-head {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		margin-bottom: 1rem;
+	}
+
+	.panel-icon {
+		position: relative;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 2.25rem;
+		height: 2.25rem;
+		border-radius: 0.625rem;
+		background: var(--docs-btn-gradient);
+		color: white;
+		box-shadow:
+			0 2px 0 rgba(255, 255, 255, 0.35) inset,
+			0 -1px 2px rgba(0, 0, 0, 0.1) inset,
+			0 4px 12px var(--docs-glow);
+		border: 1px solid rgba(255, 255, 255, 0.15);
+		flex-shrink: 0;
+	}
+
+	.panel-icon-shine {
+		position: absolute;
+		top: 2px;
+		left: 15%;
+		right: 15%;
+		height: 40%;
+		background: linear-gradient(180deg, rgba(255, 255, 255, 0.45) 0%, rgba(255, 255, 255, 0.1) 60%, transparent 100%);
+		border-radius: 0.4rem 0.4rem 50% 50%;
+		pointer-events: none;
+	}
+
+	.panel-title {
+		font-family: 'Exo 2', sans-serif;
+		font-size: 1.05rem;
+		font-weight: 600;
+		color: var(--docs-text);
+		margin: 0;
+	}
+
+	.panel-list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.panel-link {
+		display: flex;
+		flex-direction: column;
+		gap: 0.15rem;
+		padding: 0.6rem 0.7rem;
+		border-radius: 0.6rem;
+		text-decoration: none;
+		border: 1px solid transparent;
+		transition: all 0.18s cubic-bezier(0.16, 1, 0.3, 1);
+	}
+
+	.panel-link:hover {
+		background: var(--docs-surface);
+		border-color: var(--docs-border);
+		box-shadow: 0 1px 0 var(--docs-inner-highlight) inset;
+	}
+
+	.link-title {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		font-size: 0.9rem;
+		font-weight: 600;
+		color: var(--docs-text);
+	}
+
+	.link-title :global(svg) {
+		opacity: 0;
+		transform: translateX(-4px);
+		transition: all 0.18s cubic-bezier(0.16, 1, 0.3, 1);
+		color: var(--docs-accent);
+	}
+
+	.panel-link:hover .link-title {
+		color: var(--docs-accent);
+	}
+
+	.panel-link:hover .link-title :global(svg) {
+		opacity: 1;
+		transform: translateX(0);
+	}
+
+	.link-desc {
+		font-size: 0.8rem;
+		line-height: 1.45;
+		color: var(--docs-text-muted);
+	}
+
+	@media (max-width: 768px) {
+		.docs-home {
+			padding: 2rem 1rem 3rem;
+		}
+
+		.section-grid {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.doc-bubble {
+			animation: none;
+		}
+	}
+</style>

--- a/src/routes/docs/+page.ts
+++ b/src/routes/docs/+page.ts
@@ -1,8 +1,28 @@
-import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
+import { docsNav } from '$lib/config/docs-nav';
+
+// Pull frontmatter from every doc so the index can show real descriptions.
+const modules = import.meta.glob('/src/content/docs/**/*.md', { eager: true });
 
 export const prerender = true;
 
 export const load: PageLoad = () => {
-	redirect(301, '/docs/overview/introduction');
+	const meta: Record<string, { title?: string; description?: string }> = {};
+	for (const [path, mod] of Object.entries(modules)) {
+		const slug = path.replace('/src/content/docs/', '').replace('.md', '');
+		meta[slug] =
+			((mod as { metadata?: { title?: string; description?: string } }).metadata) ?? {};
+	}
+
+	const sections = docsNav.map((section) => ({
+		title: section.title,
+		icon: section.icon,
+		items: section.items.map((item) => ({
+			title: item.title,
+			slug: item.slug,
+			description: meta[item.slug]?.description ?? ''
+		}))
+	}));
+
+	return { sections };
 };

--- a/src/routes/docs/[...slug]/+page.svelte
+++ b/src/routes/docs/[...slug]/+page.svelte
@@ -1,27 +1,76 @@
 <script lang="ts">
 	import Icon from '$lib/components/ui/Icon.svelte';
 	import DocsPrevNext from '$lib/components/docs/DocsPrevNext.svelte';
-	import { SITE_URL } from '$lib/config/site';
+	import { DOCS_URL } from '$lib/config/site';
+	import { docsNav } from '$lib/config/docs-nav';
+	import { localPath } from '$lib/config/links';
 	import { addCodeCopyButtons } from '$lib/utils/add-code-copy-buttons';
+	import { browser } from '$app/environment';
 	import '$lib/styles/prose.css';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
 
 	let copied = $state(false);
+	let articleEl = $state<HTMLElement | null>(null);
+	let toc = $state<Array<{ id: string; text: string; level: number }>>([]);
+	let activeId = $state('');
+
+	// Which nav section does this page live under? (for the breadcrumb)
+	const section = $derived(docsNav.find((s) => s.items.some((i) => i.slug === data.slug)));
 
 	async function copyPage() {
 		const article = document.querySelector('.docs-content') as HTMLElement | null;
 		if (!article) return;
-		const text = article.innerText;
-		await navigator.clipboard.writeText(text);
+		await navigator.clipboard.writeText(article.innerText);
 		copied = true;
 		setTimeout(() => (copied = false), 2000);
 	}
 
+	function scrollToHeading(e: MouseEvent, id: string) {
+		e.preventDefault();
+		const el = document.getElementById(id);
+		if (!el) return;
+		el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+		history.replaceState(null, '', `#${id}`);
+		activeId = id;
+	}
+
+	// Rebuild the on-page table of contents whenever the doc changes.
 	$effect(() => {
 		void data.content;
-		addCodeCopyButtons('.docs-content');
+		if (!browser || !articleEl) return;
+
+		let observer: IntersectionObserver | null = null;
+		const raf = requestAnimationFrame(() => {
+			addCodeCopyButtons('.docs-content');
+
+			const headings = Array.from(
+				articleEl!.querySelectorAll<HTMLElement>('h2[id], h3[id]')
+			);
+			toc = headings.map((h) => ({
+				id: h.id,
+				text: h.textContent ?? '',
+				level: h.tagName === 'H3' ? 3 : 2
+			}));
+			activeId = headings[0]?.id ?? '';
+
+			if (!headings.length) return;
+			observer = new IntersectionObserver(
+				(entries) => {
+					for (const entry of entries) {
+						if (entry.isIntersecting) activeId = (entry.target as HTMLElement).id;
+					}
+				},
+				{ rootMargin: '0px 0px -75% 0px', threshold: 0 }
+			);
+			headings.forEach((h) => observer!.observe(h));
+		});
+
+		return () => {
+			cancelAnimationFrame(raf);
+			observer?.disconnect();
+		};
 	});
 </script>
 
@@ -35,19 +84,19 @@
 	{#if data.metadata?.description}
 		<meta property="og:description" content={data.metadata.description} />
 	{/if}
-	<meta property="og:url" content={`${SITE_URL}/docs/${data.slug}`} />
+	<meta property="og:url" content={`${DOCS_URL}/${data.slug}`} />
 	<meta name="twitter:card" content="summary" />
 	<meta name="twitter:title" content={data.metadata?.title || 'Docs'} />
 	{#if data.metadata?.description}
 		<meta name="twitter:description" content={data.metadata.description} />
 	{/if}
-	<link rel="canonical" href={`${SITE_URL}/docs/${data.slug}`} />
+	<link rel="canonical" href={`${DOCS_URL}/${data.slug}`} />
 	{@html `<script type="application/ld+json">${JSON.stringify({
 		'@context': 'https://schema.org',
 		'@type': 'TechArticle',
 		headline: data.metadata?.title,
 		description: data.metadata?.description,
-		url: `${SITE_URL}/docs/${data.slug}`,
+		url: `${DOCS_URL}/${data.slug}`,
 		publisher: {
 			'@type': 'Organization',
 			name: 'Utsuwa',
@@ -57,22 +106,105 @@
 	{@html '<style>html { scroll-padding-top: 6rem; }</style>'}
 </svelte:head>
 
-<article class="docs-content prose">
-	<div class="page-toolbar">
-		<button type="button" class="copy-page-btn" onclick={copyPage} title="Copy page content">
-			<Icon name={copied ? 'check' : 'copy'} size={14} />
-			<span>{copied ? 'Copied' : 'Copy page'}</span>
-		</button>
+<div class="doc-wrap">
+	<div class="doc-main">
+		<nav class="breadcrumb" aria-label="Breadcrumb">
+			<a href={localPath('docs')}>Docs</a>
+			{#if section}
+				<Icon name="chevron-right" size={12} />
+				<span class="crumb-section">{section.title}</span>
+			{/if}
+			<Icon name="chevron-right" size={12} />
+			<span class="crumb-current">{data.metadata?.title || 'Page'}</span>
+		</nav>
+
+		<article class="docs-content prose" bind:this={articleEl}>
+			<div class="page-toolbar">
+				<button type="button" class="copy-page-btn" onclick={copyPage} title="Copy page content">
+					<Icon name={copied ? 'check' : 'copy'} size={14} />
+					<span>{copied ? 'Copied' : 'Copy page'}</span>
+				</button>
+			</div>
+			<data.content />
+			<DocsPrevNext slug={data.slug} />
+		</article>
 	</div>
-	<data.content />
-	<DocsPrevNext slug={data.slug} />
-</article>
+
+	{#if toc.length}
+		<aside class="toc" aria-label="On this page">
+			<p class="toc-title">On this page</p>
+			<ul class="toc-list">
+				{#each toc as heading}
+					<li class:sub={heading.level === 3}>
+						<a
+							href={`#${heading.id}`}
+							class:active={activeId === heading.id}
+							onclick={(e) => scrollToHeading(e, heading.id)}
+						>
+							{heading.text}
+						</a>
+					</li>
+				{/each}
+			</ul>
+		</aside>
+	{/if}
+</div>
 
 <style>
-	.docs-content {
-		max-width: 48rem;
+	.doc-wrap {
+		display: flex;
+		gap: 2.5rem;
+		max-width: 70rem;
 		margin: 0 auto;
-		padding: 2rem 3rem;
+		padding: 1.75rem 3rem 2rem;
+		align-items: flex-start;
+	}
+
+	.doc-main {
+		flex: 1;
+		min-width: 0;
+		max-width: 48rem;
+	}
+
+	.docs-content {
+		max-width: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	.docs-content :global(h2),
+	.docs-content :global(h3) {
+		scroll-margin-top: 1.25rem;
+	}
+
+	/* Breadcrumb */
+	.breadcrumb {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+		font-size: 0.78rem;
+		font-weight: 500;
+		color: var(--docs-text-muted);
+		margin-bottom: 1.25rem;
+	}
+
+	.breadcrumb a {
+		color: var(--docs-text-muted);
+		text-decoration: none;
+		transition: color 0.15s ease;
+	}
+
+	.breadcrumb a:hover {
+		color: var(--docs-accent);
+	}
+
+	.crumb-current {
+		color: var(--docs-text);
+		font-weight: 600;
+	}
+
+	.breadcrumb :global(svg) {
+		opacity: 0.5;
 	}
 
 	.page-toolbar {
@@ -117,8 +249,73 @@
 			0 0 6px var(--docs-glow);
 	}
 
+	/* On-page table of contents */
+	.toc {
+		position: sticky;
+		top: 1.5rem;
+		width: 14rem;
+		flex-shrink: 0;
+		max-height: calc(100vh - 6rem);
+		overflow-y: auto;
+		padding-top: 0.25rem;
+	}
+
+	.toc-title {
+		font-size: 0.7rem;
+		font-weight: 700;
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+		color: var(--docs-text-muted);
+		margin: 0 0 0.75rem;
+		padding-left: 0.85rem;
+	}
+
+	.toc-list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		border-left: 1px solid var(--docs-border);
+	}
+
+	.toc-list li.sub a {
+		padding-left: 1.75rem;
+		font-size: 0.78rem;
+	}
+
+	.toc-list a {
+		display: block;
+		padding: 0.32rem 0.85rem;
+		margin-left: -1px;
+		border-left: 2px solid transparent;
+		font-size: 0.82rem;
+		line-height: 1.4;
+		color: var(--docs-text-muted);
+		text-decoration: none;
+		transition: color 0.15s ease, border-color 0.15s ease;
+	}
+
+	.toc-list a:hover {
+		color: var(--docs-text);
+	}
+
+	.toc-list a.active {
+		color: var(--docs-accent);
+		border-left-color: var(--docs-accent);
+		font-weight: 600;
+	}
+
+	@media (max-width: 1100px) {
+		.toc {
+			display: none;
+		}
+
+		.doc-wrap {
+			max-width: 52rem;
+		}
+	}
+
 	@media (max-width: 768px) {
-		.docs-content {
+		.doc-wrap {
 			padding: 1.5rem 1rem;
 		}
 	}

--- a/vercel.json
+++ b/vercel.json
@@ -1,27 +1,39 @@
 {
+	"rewrites": [
+		{
+			"source": "/:path*",
+			"has": [{ "type": "host", "value": "docs.utsuwa.ai" }],
+			"destination": "/docs/:path*"
+		},
+		{
+			"source": "/:path*",
+			"has": [{ "type": "host", "value": "app.utsuwa.ai" }],
+			"destination": "/app/:path*"
+		}
+	],
 	"redirects": [
 		{
-			"source": "/",
-			"has": [{ "type": "host", "value": "app.utsuwa.ai" }],
-			"destination": "https://utsuwa.ai/app",
+			"source": "/docs",
+			"has": [{ "type": "host", "value": "utsuwa.ai" }],
+			"destination": "https://docs.utsuwa.ai",
 			"permanent": true
 		},
 		{
-			"source": "/:path+",
-			"has": [{ "type": "host", "value": "app.utsuwa.ai" }],
-			"destination": "https://utsuwa.ai/app/:path+",
+			"source": "/docs/:path*",
+			"has": [{ "type": "host", "value": "utsuwa.ai" }],
+			"destination": "https://docs.utsuwa.ai/:path*",
 			"permanent": true
 		},
 		{
-			"source": "/",
-			"has": [{ "type": "host", "value": "docs.utsuwa.ai" }],
-			"destination": "https://utsuwa.ai/docs/overview/introduction",
+			"source": "/app",
+			"has": [{ "type": "host", "value": "utsuwa.ai" }],
+			"destination": "https://app.utsuwa.ai",
 			"permanent": true
 		},
 		{
-			"source": "/:path+",
-			"has": [{ "type": "host", "value": "docs.utsuwa.ai" }],
-			"destination": "https://utsuwa.ai/docs/:path+",
+			"source": "/app/:path*",
+			"has": [{ "type": "host", "value": "utsuwa.ai" }],
+			"destination": "https://app.utsuwa.ai/:path*",
 			"permanent": true
 		}
 	]


### PR DESCRIPTION
A fairly big pass over the public side of the site. Three things ended up bundled together because they grew out of the same work.

## Landing page
Rebuilt it so it feels less templated and more like us. New hero with the Frutiger Aero glass treatment, drifting bubbles, a provider strip showing the actual LLM and voice logos, and a bento grid for the rest of the features. It also has light/dark mode now (it had none before), with a toggle that shares the app's existing colorMode so the whole site stays in sync.

## Docs
`/docs` used to just redirect straight to the intro. It's a real landing page now: search, get-started cards, and a browse-by-section grid. Individual pages picked up breadcrumbs and a sticky "on this page" table of contents, plus the same glassy styling so they stop feeling disconnected from the marketing pages.

## Blog
It was hard-locked to light mode. Now it follows the shared theme and gets the gradient titles, ambient glow, and dark glass cards like everything else.

## Subdomains
`docs.utsuwa.ai` and `app.utsuwa.ai` now serve the docs and app with clean URLs (no `/docs` or `/app` in the path). This is done with host-based rewrites in `vercel.json`, a `reroute` hook for client-side navigation, and a small host-aware link helper so links stay clean on the real domain but keep working in local dev and on preview deploys. The old `/docs` and `/app` paths 301 to the subdomains. The domains were already attached to the Vercel project, so no DNS changes were needed.

## Testing
- `pnpm check` is clean (0 errors)
- Checked light and dark across the landing page, docs, and blog
- Simulated the subdomains locally with `Host` headers: clean URLs resolve to the right routes, cross-section links go absolute, in-section links stay relative
- Preview deploy builds green
