### PR TITLE
Fix: docs and app subdomains showing the landing page at their root

### DIFF
--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,6 +1,9 @@
 import type { PageLoad } from './$types';
 
-export const prerender = true;
+// Not prerendered: the subdomains (docs/app) rewrite their root to /docs and
+// /app, and a static "/" would otherwise win on every host and show the
+// landing page there. SSR keeps "/" host-aware via the reroute hook.
+export const prerender = false;
 
 const modules = import.meta.glob('/src/content/blog/*.md', { eager: true });
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,14 +1,24 @@
 {
 	"rewrites": [
 		{
-			"source": "/:path*",
+			"source": "/",
 			"has": [{ "type": "host", "value": "docs.utsuwa.ai" }],
-			"destination": "/docs/:path*"
+			"destination": "/docs"
 		},
 		{
-			"source": "/:path*",
+			"source": "/:path+",
+			"has": [{ "type": "host", "value": "docs.utsuwa.ai" }],
+			"destination": "/docs/:path+"
+		},
+		{
+			"source": "/",
 			"has": [{ "type": "host", "value": "app.utsuwa.ai" }],
-			"destination": "/app/:path*"
+			"destination": "/app"
+		},
+		{
+			"source": "/:path+",
+			"has": [{ "type": "host", "value": "app.utsuwa.ai" }],
+			"destination": "/app/:path+"
 		}
 	],
 	"redirects": [


### PR DESCRIPTION
Quick follow-up to #22. The subdomains worked for every path except their root: `docs.utsuwa.ai/` and `app.utsuwa.ai/` were showing the marketing landing page instead of the docs hub and the app.

The cause: the landing page (`/`) is prerendered, so Vercel served that static `/index.html` on every host before the host-based rewrites could kick in (those only apply as a fallback when nothing else matches). Subpaths like `/overview/introduction` and `/settings/display` didn't collide with anything, which is why they worked.

Fix:
- Stop prerendering `/`. It's SSR now, so it stays host-aware through the reroute hook, and there's no static `/` to shadow the subdomains.
- Map each subdomain root explicitly in `vercel.json` (`/` -> `/docs` and `/` -> `/app`) instead of relying on the catch-all, which also avoids a trailing-slash redirect on the docs root.

Docs and blog pages are still prerendered (confirmed in the build output), so search and static delivery are unaffected. The only page that moves to SSR is the homepage.

Verified the production build succeeds and that `index.html` is no longer in the prerendered output while `docs/*` still is.
